### PR TITLE
Use HTTPS instead of SSH for JUCE submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "modules/juce"]
 	path = modules/juce
-	url = git@github.com:WeAreROLI/JUCE.git
+	url = https://github.com/WeAreROLI/JUCE
 	branch = develop


### PR DESCRIPTION
Using `pluginval` as a Git submodule is not as straightforward as it should be when using CI/CD services such as Travis-CI and AppVeyor, because `pluginval` uses `JUCE` as a Git submodule using SSH (`git@github.com:WeAreROLI/JUCE.git`).

As `JUCE` is hosted publicly on GitHub, there is no need for SSH cloning and consequently using HTTPS cloning is way more convenient is this case.