### PR TITLE
fix: Do not call startPeriodicEventsAfterDelay multiple times

### DIFF
--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -96,9 +96,13 @@ void CommandLineValidator::itemComplete (const String& id, int numItemFailures)
 void CommandLineValidator::allItemsComplete()
 {
     if (numFailures > 0)
+    {
         exitWithError ("*** FAILED: " + String (numFailures) + " TESTS");
-
-    JUCEApplication::getInstance()->quit();
+    }
+    else
+    {
+        JUCEApplication::getInstance()->quit();
+    }
 }
 
 void CommandLineValidator::connectionLost()


### PR DESCRIPTION
Before this change we could end up calling the below function async:

(juce_mac_MessageManager.mm)

static void shutdownNSApp()
{
    [NSApp stop: nil];
    [NSEvent startPeriodicEventsAfterDelay: 0  withPeriod: 0.1];
}

Calling [NSEvent startPeriodicEventsAfterDelay: 0  withPeriod: 0.1];
multiple times terminates the app with:

Terminating app due to uncaught exception 'NSInternalInconsistencyException', reason: 'Periodic events are already being generated'