### PR TITLE
Add visual studio2019 export

### DIFF
--- a/install/windows_build.bat
+++ b/install/windows_build.bat
@@ -11,11 +11,11 @@ set DEPLOYMENT_DIR=%ROOT%\bin\windows
 
 set BINARY_NAME=%PROJECT_NAME%.exe
 set APP_NAME=%BINARY_NAME%
-set APP_FILE="%ROOT%\Builds\VisualStudio2017\x64\Release\App\%APP_NAME%"
+set APP_FILE="%ROOT%\Builds\VisualStudio2019\x64\Release\App\%APP_NAME%"
 
 set ZIP_FILE="%DEPLOYMENT_DIR%\%PROJECT_NAME%_Windows.zip"
 
-if not defined MSBUILD_EXE set MSBUILD_EXE=C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\MSBuild\15.0\Bin\MSBuild.exe
+if not defined MSBUILD_EXE set MSBUILD_EXE=c:\Program Files (x86)\Microsoft Visual Studio\2019\Community\MSBuild\Current\Bin\MSBuild.exe
 
 :: First clear the bin
 echo "=========================================================="
@@ -26,12 +26,12 @@ rd /S /Q "%ROOT%\bin\windows"
 ::   Build Projucer and generate projects
 ::============================================================
 echo "Building Projucer and creating projects"
-set PROJUCER_ROOT=%ROOT%/modules/juce/extras/Projucer/Builds/VisualStudio2017
+set PROJUCER_ROOT=%ROOT%/modules/juce/extras/Projucer/Builds/VisualStudio2019
 set PROJUCER_EXE=%PROJUCER_ROOT%/x64/Release/App/Projucer.exe
 
 cd "%PROJUCER_ROOT%"
 set CL=/DJUCER_ENABLE_GPL_MODE
-"%MSBUILD_EXE%" Projucer.sln /p:VisualStudioVersion=15.0 /m /p:Configuration=Release /p:Platform=x64 /p:PreferredToolArchitecture=x64
+"%MSBUILD_EXE%" Projucer.sln /p:VisualStudioVersion=16.0 /m /p:Configuration=Release /p:Platform=x64 /p:PreferredToolArchitecture=x64
 if not exist "%PROJUCER_EXE%" exit 1
 
 :: Resave project
@@ -72,9 +72,9 @@ if not exist "%VST2_SDK_DIR%" goto SKIP_VST2_SUPPORT
 ::============================================================
 echo "=========================================================="
 echo "Building products"
-cd "%ROOT%/Builds/VisualStudio2017"
+cd "%ROOT%/Builds/VisualStudio2019"
 rd /S /Q "x64/Release"
-"%MSBUILD_EXE%" %PROJECT_NAME%.sln /p:VisualStudioVersion=15.0 /m /t:Build /p:Configuration=Release /p:Platform=x64 /p:PreferredToolArchitecture=x64  /p:TreatWarningsAsErrors=true
+"%MSBUILD_EXE%" %PROJECT_NAME%.sln /p:VisualStudioVersion=16.0 /m /t:Build /p:Configuration=Release /p:Platform=x64 /p:PreferredToolArchitecture=x64  /p:TreatWarningsAsErrors=true
 
 
 ::============================================================

--- a/pluginval.jucer
+++ b/pluginval.jucer
@@ -65,6 +65,26 @@
         <MODULEPATH id="juce_audio_processors" path="modules/juce/modules"/>
       </MODULEPATHS>
     </XCODE_MAC>
+    <VS2019 targetFolder="Builds/VisualStudio2019" smallIcon="k3tDOE" bigIcon="k3tDOE"
+            vst3Folder="modules/vst3">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug" targetName="pluginval" useRuntimeLibDLL="0"/>
+        <CONFIGURATION isDebug="0" name="Release" warningsAreErrors="1" targetName="pluginval"
+                       alwaysGenerateDebugSymbols="1" useRuntimeLibDLL="0"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_gui_extra" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_gui_basics" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_graphics" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_events" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_data_structures" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_core" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_audio_processors" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_audio_formats" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_audio_devices" path="modules/juce/modules"/>
+        <MODULEPATH id="juce_audio_basics" path="modules/juce/modules"/>
+      </MODULEPATHS>
+    </VS2019>
     <VS2017 targetFolder="Builds/VisualStudio2017" smallIcon="k3tDOE" bigIcon="k3tDOE"
             vst3Folder="modules/vst3">
       <CONFIGURATIONS>

--- a/pluginval.jucer
+++ b/pluginval.jucer
@@ -69,7 +69,7 @@
             vst3Folder="modules/vst3">
       <CONFIGURATIONS>
         <CONFIGURATION isDebug="1" name="Debug" targetName="pluginval" useRuntimeLibDLL="0"/>
-        <CONFIGURATION isDebug="0" name="Release" warningsAreErrors="1" targetName="pluginval"
+        <CONFIGURATION isDebug="0" name="Release" warningsAreErrors="0" targetName="pluginval"
                        alwaysGenerateDebugSymbols="1" useRuntimeLibDLL="0"/>
       </CONFIGURATIONS>
       <MODULEPATHS>


### PR DESCRIPTION
Fixes #23

Unfortunately I had to set warningsAreErrors to 0 because vs2019 finds several warnings into the JUCE library.