### PR TITLE
Fix handling of `--disabled-tests` options

### DIFF
--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -474,7 +474,7 @@ private:
             options.dataFile = File (v[IDs::dataFile].toString());
             options.outputDir = File (v[IDs::outputDir].toString());
             options.withGUI = v.getProperty (IDs::withGUI, true);
-            options.disabledTests = StringArray::fromTokens (v.getProperty (IDs::disabledTests).toString(), false);
+            options.disabledTests = StringArray::fromLines (v.getProperty (IDs::disabledTests).toString());
 
             for (auto c : v)
             {


### PR DESCRIPTION
overview (mainly my explanation of the feature, i could be missing something):

tests to be disabled are listed by name in an external file, one per line. e.g:

```
Plugin info
Plugin programs
Editor
Open editor whilst processing
Audio processing
Plugin state
Automation
Editor Automation
Automatable Parameters
Basic bus
```

these are read from disk line-by-line into an array, and later put back together into a single string with a newline ("\n") separator, presumably for marshalling over IPC.

before this fix, there was an attempt to split these out again using an overload of `StringArray::fromTokens`(introduced in 3b1adf324c1b1d31866992cb6d74642199fe6d91) which uses whitespace delimiters, ultimately causing test cases with spaces in their names to not be disabled (e.g. "Automatable Parameters" ends up in the options array as two entries, so the test case isn't picked up as a match). using `StringArray::fromLines` fixes the issue.

i considered trying to write a failing unit test before fixing this, but it'd have been a little fiddly without changing the shape of things. (involves reading from a file, exercising implementation details of `Validator`, somehow inspecting how many tests were run etc. more of an integration test really). 