### PR TITLE
Make pathological scheduling slightly less likely

### DIFF
--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -423,9 +423,13 @@ private:
         {
             processRequests();
 
-            const ScopedLock sl (requestsLock);
+            auto noRequests = [&]
+            {
+                const ScopedLock sl (requestsLock);
+                return requestsToProcess.empty();
+            }();
 
-            if (requestsToProcess.empty())
+            if (noRequests)
                 Thread::sleep (500);
         }
 


### PR DESCRIPTION
I was seeing deadlock-like behaviour (frozen UI after starting
validatation) when debugging with tsan/gcc/ubuntu in a VM. I was testing
using the 'validate in process' option, and using strictness 10.

When I paused the debugger during the 'deadlock' it looked like the main
thread was waiting on the requestsLock, but I couldn't see any other
threads which had taken the requestsLock and which were waiting on
another lock owned by the main thread.

I think that the problem is due to ValidatorChildProcess keeping the
requestsLock locked for the majority of the run loop. This doesn't give
other threads a very large window to progress on calls to addRequest. If
I modify the code to only lock the requestsLock when modifying shared
resources, the deadlock-like symptoms go away, and validation can start
successfully.