### PR TITLE
Disable curl in the Projucer export

### DIFF
--- a/pluginval.jucer
+++ b/pluginval.jucer
@@ -118,5 +118,5 @@
     <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
   </MODULES>
   <JUCEOPTIONS JUCE_PLUGINHOST_AU="1" JUCE_PLUGINHOST_VST3="1" JUCE_PLUGINHOST_LADSPA="1"
-               JUCE_WEB_BROWSER="0"/>
+               JUCE_WEB_BROWSER="0" JUCE_USE_CURL="0"/>
 </JUCERPROJECT>


### PR DESCRIPTION
Avoid linking curl when using the Projucer-based build. The cmake build already has the option.
Currently it's impossible to run the pluginval binary in Gihub Actions `ubuntu-18.04`, using the documented steps.
```
./pluginval: /usr/lib/x86_64-linux-gnu/libcurl.so.4: version `CURL_OPENSSL_3' not found (required by ./pluginval)
```