### PR TITLE
add option to select sample rates and block sizes

### DIFF
--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -173,6 +173,22 @@ File getOutputDir (const ArgumentList& args)
     return getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString();
 }
 
+StringArray getSampleRates (const ArgumentList& args)
+{
+    return StringArray::fromTokens(getOptionValue (args, "--sample-rates", String ("44100,48000,96000") , "Missing sample rate list argument!").toString(),
+                                   ",",
+                                   "\""
+                                   );
+}
+
+StringArray getBlockSizes (const ArgumentList& args)
+{
+    return StringArray::fromTokens(getOptionValue (args, "--block-sizes", String ("64,128,256,512,1024") , "Missing block size list argument!").toString(),
+                                   ",",
+                                   "\""
+                                   );
+}
+
 StringArray getDisabledTest (const ArgumentList& args)
 {
     const File disabledTestsFile (getOptionValue (args, "--disabled-tests", {}, "Missing disabled-tests path argument!").toString());
@@ -221,7 +237,9 @@ static Option possibleOptions[] =
     { "--data-file",            true    },
     { "--output-dir",           true    },
     { "--repeat",               true    },
-    { "--randomise",            false   }
+    { "--randomise",            false   },
+    { "--sample-rates",         true    },
+    { "--block-sizes",          true    }, 
 };
 
 StringArray mergeEnvironmentVariables (StringArray args, std::function<String (const String& name, const String& defaultValue)> environmentVariableProvider = [] (const String& name, const String& defaultValue) { return SystemStats::getEnvironmentVariable (name, defaultValue); })
@@ -292,6 +310,10 @@ static String getHelpMessage()
          << "    If specified, sets a directory to store the log files. This can be useful for continuous integration." << newLine
          << "  --disabled-tests [pathToFile]" << newLine
          << "    If specified, sets a path to a file that should have the names of disabled tests on each row." << newLine
+         << "  --sample-rates [list of comma separated sample rates]" << newLine
+         << "    If specified, sets the list of sample rates at which tests will be executed (default=44100,48000,96000)" << newLine
+         << "  --block-sizes [list of comma separated block sizes]" << newLine
+         << "    If specified, sets the list of block sizes at which tests will be executed (default=64,128,256,512,1024)" << newLine
          << "  --version" << newLine
          << "    Print pluginval version." << newLine
          << newLine
@@ -352,6 +374,8 @@ static void validate (CommandLineValidator& validator, const ArgumentList& args)
         options.outputDir = getOutputDir (args);
         options.withGUI = ! args.containsOption ("--skip-gui-tests");
         options.disabledTests = getDisabledTest (args);
+        options.sampleRates = getSampleRates (args);
+        options.blockSizes = getBlockSizes (args);
 
         validator.validate (fileOrIDs,
                             options,

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -173,20 +173,30 @@ File getOutputDir (const ArgumentList& args)
     return getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString();
 }
 
-StringArray getSampleRates (const ArgumentList& args)
+std::vector<double> getSampleRates (const ArgumentList& args)
 {
-    return StringArray::fromTokens(getOptionValue (args, "--sample-rates", String ("44100,48000,96000") , "Missing sample rate list argument!").toString(),
+    StringArray input = StringArray::fromTokens(getOptionValue (args, "--sample-rates", String ("44100,48000,96000") , "Missing sample rate list argument!").toString(),
                                    ",",
                                    "\""
                                    );
+    std::vector<double> output;
+    for(String sr: input)  {
+        output.push_back(sr.getDoubleValue());
+    }  
+    return output;
 }
 
-StringArray getBlockSizes (const ArgumentList& args)
+std::vector<int> getBlockSizes (const ArgumentList& args)
 {
-    return StringArray::fromTokens(getOptionValue (args, "--block-sizes", String ("64,128,256,512,1024") , "Missing block size list argument!").toString(),
+    StringArray input = StringArray::fromTokens(getOptionValue (args, "--block-sizes", String ("64,128,256,512,1024") , "Missing block size list argument!").toString(),
                                    ",",
                                    "\""
                                    );
+    std::vector<int> output;
+    for(String sr: input)  {
+        output.push_back(sr.getIntValue());
+    }  
+    return output;
 }
 
 StringArray getDisabledTest (const ArgumentList& args)

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -92,14 +92,14 @@ File getOutputDir()
     return getAppPreferences().getValue ("outputDir", String());
 }
 
-StringArray getSampleRates() // from UI no setting of sampleRates yet 
+std::vector<double> getSampleRates() // from UI no setting of sampleRates yet
 {
-    return {"44100","48000","96000"};
+    return {44100., 48000., 96000. };
 }
 
-StringArray getBlockSizes() // from UI no setting of block sizes yet
+std::vector<int> getBlockSizes() // from UI no setting of block sizes yet
 {
-    return  { "64", "128", "256", "512", "1024" };
+    return { 64, 128, 256, 512, 1024 };
 }
 
 

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -92,6 +92,16 @@ File getOutputDir()
     return getAppPreferences().getValue ("outputDir", String());
 }
 
+StringArray getSampleRates() // from UI no setting of sampleRates yet 
+{
+    return {"44100","48000","96000"};
+}
+
+StringArray getBlockSizes() // from UI no setting of block sizes yet
+{
+    return  { "64", "128", "256", "512", "1024" };
+}
+
 
 PluginTests::Options getTestOptions()
 {
@@ -103,6 +113,8 @@ PluginTests::Options getTestOptions()
     options.numRepeats = getNumRepeats();
     options.randomiseTestOrder = getRandomiseTests();
     options.outputDir = getOutputDir();
+    options.sampleRates = getSampleRates();
+    options.blockSizes = getBlockSizes();
 
     return options;
 }

--- a/Source/PluginTests.h
+++ b/Source/PluginTests.h
@@ -36,8 +36,8 @@ struct PluginTests : public UnitTest
         File dataFile;                      /**< File which tests can use to run user provided data. */
         File outputDir;                     /**< Directory in which to write the log files for each test run. */
         StringArray disabledTests;          /**< List of disabled tests. */
-        StringArray sampleRates;            /**< List of sample rates. */
-        StringArray blockSizes;             /**< List of block sizes. */
+        std::vector<double> sampleRates;    /**< List of sample rates. */
+        std::vector<int> blockSizes;        /**< List of block sizes. */
     };
 
     /** Creates a set of tests for a fileOrIdentifier. */

--- a/Source/PluginTests.h
+++ b/Source/PluginTests.h
@@ -36,6 +36,8 @@ struct PluginTests : public UnitTest
         File dataFile;                      /**< File which tests can use to run user provided data. */
         File outputDir;                     /**< Directory in which to write the log files for each test run. */
         StringArray disabledTests;          /**< List of disabled tests. */
+        StringArray sampleRates;            /**< List of sample rates. */
+        StringArray blockSizes;             /**< List of block sizes. */
     };
 
     /** Creates a set of tests for a fileOrIdentifier. */

--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -249,6 +249,8 @@ namespace IDs
     DECLARE_ID(outputDir)
     DECLARE_ID(withGUI)
     DECLARE_ID(disabledTests)
+    DECLARE_ID(sampleRates)
+    DECLARE_ID(blockSizes)
 
     DECLARE_ID(MESSAGE)
     DECLARE_ID(type)
@@ -479,7 +481,9 @@ private:
             options.outputDir = File (v[IDs::outputDir].toString());
             options.withGUI = v.getProperty (IDs::withGUI, true);
             options.disabledTests = StringArray::fromLines (v.getProperty (IDs::disabledTests).toString());
-
+            options.sampleRates = StringArray::fromLines (v.getProperty (IDs::sampleRates).toString());
+            options.blockSizes = StringArray::fromLines (v.getProperty (IDs::blockSizes).toString());
+            
             for (auto c : v)
             {
                 String fileOrID;
@@ -670,6 +674,8 @@ private:
         v.setProperty (IDs::outputDir, options.outputDir.getFullPathName(), nullptr);
         v.setProperty (IDs::withGUI, options.withGUI, nullptr);
         v.setProperty (IDs::disabledTests, options.disabledTests.joinIntoString ("\n"), nullptr);
+        v.setProperty (IDs::sampleRates, options.sampleRates.joinIntoString ("\n"), nullptr);
+        v.setProperty (IDs::blockSizes, options.blockSizes.joinIntoString ("\n"), nullptr);
 
         return v;
     }

--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -481,8 +481,8 @@ private:
             options.outputDir = File (v[IDs::outputDir].toString());
             options.withGUI = v.getProperty (IDs::withGUI, true);
             options.disabledTests = StringArray::fromLines (v.getProperty (IDs::disabledTests).toString());
-            options.sampleRates = StringArray::fromLines (v.getProperty (IDs::sampleRates).toString());
-            options.blockSizes = StringArray::fromLines (v.getProperty (IDs::blockSizes).toString());
+            options.sampleRates = juce::VariantConverter<std::vector<double>>::fromVar( v.getProperty (IDs::sampleRates).toString() );
+            options.blockSizes  = juce::VariantConverter<std::vector<int>>::fromVar( v.getProperty (IDs::blockSizes).toString() );
             
             for (auto c : v)
             {
@@ -674,8 +674,8 @@ private:
         v.setProperty (IDs::outputDir, options.outputDir.getFullPathName(), nullptr);
         v.setProperty (IDs::withGUI, options.withGUI, nullptr);
         v.setProperty (IDs::disabledTests, options.disabledTests.joinIntoString ("\n"), nullptr);
-        v.setProperty (IDs::sampleRates, options.sampleRates.joinIntoString ("\n"), nullptr);
-        v.setProperty (IDs::blockSizes, options.blockSizes.joinIntoString ("\n"), nullptr);
+        v.setProperty (IDs::sampleRates, juce::VariantConverter<std::vector<double>>::toVar(options.sampleRates), nullptr);
+        v.setProperty (IDs::blockSizes, juce::VariantConverter<std::vector<int>>::toVar(options.blockSizes), nullptr);
 
         return v;
     }

--- a/Source/Validator.h
+++ b/Source/Validator.h
@@ -25,6 +25,34 @@
  #define LOG_PIPE_CHILD_COMMUNICATION 0
 #endif
 
+namespace juce
+{
+template<typename T>
+struct VariantConverter<std::vector<T>>
+{
+    static std::vector<T> fromVar (const var& v)
+    {
+        jassert (v.isArray());
+        Array<var>*    vr = v.getArray();
+        std::vector<T> vc;
+        for (var vItem : *vr)
+        {
+            vc.push_back (static_cast<T> (vItem));
+        }
+        return vc;
+    }
+    static var toVar (const std::vector<T>& vc)
+    {
+        juce::var vr;
+        for (T t : vc)
+        {
+            vr.append (t);
+        }
+        return vr;
+    }
+};
+}// namespace juce
+
 class ValidatorParentProcess;
 
 //==============================================================================

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -135,11 +135,11 @@ struct EditorWhilstProcessingTest   : public PluginTest
         {
             instance.releaseResources();
 
-            const StringArray& sampleRates = ut.getOptions().sampleRates;
-            const StringArray& blockSizes = ut.getOptions().blockSizes;
+            const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
+            const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
             
             jassert (sampleRates.size()>0 && blockSizes.size()>0);
-            instance.prepareToPlay (sampleRates[0].getDoubleValue(), blockSizes[0].getIntValue());
+            instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
             const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
             AudioBuffer<float> ab (numChannelsRequired, instance.getBlockSize());
@@ -189,11 +189,11 @@ struct AudioProcessingTest  : public PluginTest
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
         
-        const StringArray& sampleRates = ut.getOptions().sampleRates;
-        const StringArray& blockSizes = ut.getOptions().blockSizes;
+        const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
+        const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
         
         jassert (sampleRates.size()>0 && blockSizes.size()>0);
-        instance.prepareToPlay (sampleRates[0].getDoubleValue(), blockSizes[0].getIntValue());
+        instance.prepareToPlay (sampleRates[0], blockSizes[0]);
                
         const int numBlocks = 10;
         auto r = ut.getRandom();
@@ -203,16 +203,16 @@ struct AudioProcessingTest  : public PluginTest
             for (auto bs : blockSizes)
             {
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                               .replace ("SR", sr, false)
-                            .replace ("BS", bs, false));
+                               .replace ("SR", String(sr,0) , false)
+                            .replace ("BS", String(bs), false));
                 
                 if (callReleaseResourcesBeforeSampleRateChange)
                     instance.releaseResources();
                 
-                instance.prepareToPlay (sr.getDoubleValue(), bs.getIntValue());
+                instance.prepareToPlay (sr, bs);
 
                 const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs.getIntValue());
+                AudioBuffer<float> ab (numChannelsRequired, bs);
                 MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
@@ -220,7 +220,7 @@ struct AudioProcessingTest  : public PluginTest
                 const int noteNumber = r.nextInt (128);
 
                 if (isPluginInstrument)
-                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs.getIntValue()));
+                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs));
 
                 for (int i = 0; i < numBlocks; ++i)
                 {
@@ -355,11 +355,11 @@ struct AutomationTest  : public PluginTest
         const bool subnormalsAreErrors = ut.getOptions().strictnessLevel > 5;
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
         
-        const StringArray& sampleRates = ut.getOptions().sampleRates;
-        const StringArray& blockSizes = ut.getOptions().blockSizes;
+        const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
+        const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
         
         jassert (sampleRates.size()>0 && blockSizes.size()>0);
-        instance.prepareToPlay (sampleRates[0].getDoubleValue(), blockSizes[0].getIntValue());
+        instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
         auto r = ut.getRandom();
 
@@ -369,16 +369,16 @@ struct AutomationTest  : public PluginTest
             {
                 const int subBlockSize = 32;
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS] and sub-block size [SB]")
-                            .replace ("SR", sr, false)
-                            .replace ("BS", bs, false)
+                            .replace ("SR", String(sr,0), false)
+                            .replace ("BS", String(bs), false)
                             .replace ("SB", String (subBlockSize), false));
 
                 instance.releaseResources();
-                instance.prepareToPlay (sr.getDoubleValue(), bs.getIntValue());
+                instance.prepareToPlay (sr, bs);
 
                 int numSamplesDone = 0;
                 const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs.getIntValue());
+                AudioBuffer<float> ab (numChannelsRequired, bs);
                 MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
@@ -402,10 +402,10 @@ struct AutomationTest  : public PluginTest
                     }
 
                     // Create a sub-buffer and process
-                    const int numSamplesThisTime = jmin (subBlockSize, bs.getIntValue() - numSamplesDone);
+                    const int numSamplesThisTime = jmin (subBlockSize, bs - numSamplesDone);
 
                     // Trigger a note off in the last sub block
-                    if (isPluginInstrument && (bs.getIntValue() - numSamplesDone) <= subBlockSize)
+                    if (isPluginInstrument && (bs - numSamplesDone) <= subBlockSize)
                         addNoteOff (mb, noteChannel, noteNumber, jmin (10, subBlockSize));
 
                     AudioBuffer<float> subBuffer (ab.getArrayOfWritePointers(),
@@ -418,7 +418,7 @@ struct AutomationTest  : public PluginTest
 
                     mb.clear();
 
-                    if (numSamplesDone >= bs.getIntValue())
+                    if (numSamplesDone >= bs)
                         break;
                 }
 

--- a/Source/tests/ExtremeTests.cpp
+++ b/Source/tests/ExtremeTests.cpp
@@ -27,11 +27,11 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
  
-        const StringArray& sampleRates = ut.getOptions().sampleRates;
-        const StringArray& blockSizes = ut.getOptions().blockSizes;
+        const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
+        const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
         
         jassert (sampleRates.size()>0 && blockSizes.size()>0);
-        instance.prepareToPlay (sampleRates[0].getDoubleValue(), blockSizes[0].getIntValue());
+        instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
         const int numBlocks = 10;
         auto r = ut.getRandom();
@@ -41,13 +41,13 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
             for (auto bs : blockSizes)
             {
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                               .replace ("SR", sr, false)
-                               .replace ("BS", bs, false));
+                               .replace ("SR", String(sr,0), false)
+                               .replace ("BS", String(bs), false));
                 instance.releaseResources();
-                instance.prepareToPlay (sr.getDoubleValue(), bs.getIntValue());
+                instance.prepareToPlay (sr, bs);
 
                 const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs.getIntValue());
+                AudioBuffer<float> ab (numChannelsRequired, bs);
                 MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
@@ -55,7 +55,7 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
                 const int noteNumber = r.nextInt (128);
 
                 if (isPluginInstrument)
-                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs.getIntValue() - 1));
+                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs - 1));
 
                 for (int i = 0; i < numBlocks; ++i)
                 {
@@ -109,8 +109,8 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
             return;
         }
         
-        const StringArray& sampleRates = ut.getOptions().sampleRates;
-        const StringArray& blockSizes = ut.getOptions().blockSizes;
+        const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
+        const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
 
         jassert (sampleRates.size()>0 && blockSizes.size()>0);
         
@@ -118,13 +118,13 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
         {
             for (auto preparedBlockSize : blockSizes)
             {
-                const auto processingBlockSize = preparedBlockSize.getIntValue() * 2;
+                const auto processingBlockSize = preparedBlockSize * 2;
                 ut.logMessage (String ("Preparing with sample rate [SR] and block size [BS], processing with block size [BSP]")
-                               .replace ("SR", sr, false)
+                               .replace ("SR", String(sr,0), false)
                                .replace ("BSP", String (processingBlockSize), false)
-                               .replace ("BS", preparedBlockSize, false));
+                               .replace ("BS", String(preparedBlockSize), false));
                 instance.releaseResources();
-                instance.prepareToPlay (sr.getDoubleValue(), preparedBlockSize.getIntValue());
+                instance.prepareToPlay (sr, preparedBlockSize);
 
                 const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
                 AudioBuffer<float> ab (numChannelsRequired, processingBlockSize);


### PR DESCRIPTION
Hi there ... need to test separately for different sample rates and block sizes so added this to my fork - hope it can be useful also for other people. 

NOTE: 
This is affecting only the command line part - even tho both command line and UI testing has been adapted to use StringArrays of sample rates and block sizes, since test classes are shared.
Briefly thought about also adding a submenu on UI settings with the options to check/uncheck block sizes ans sample rates, with additional check of having at least one of both selected.
Currently thinking that's way overkill, but happy to implement that should it make sense.