### PR TITLE
Var conversion bugfix

### DIFF
--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -175,27 +175,35 @@ File getOutputDir (const ArgumentList& args)
 
 std::vector<double> getSampleRates (const ArgumentList& args)
 {
-    StringArray input = StringArray::fromTokens(getOptionValue (args, "--sample-rates", String ("44100,48000,96000") , "Missing sample rate list argument!").toString(),
-                                   ",",
-                                   "\""
-                                   );
+    StringArray input = StringArray::fromTokens (getOptionValue (args,
+                                                                 "--sample-rates",
+                                                                 String ("44100,48000,96000"),
+                                                                 "Missing sample rate list argument!")
+                                                     .toString(),
+                                                 ",",
+                                                 "\"");
     std::vector<double> output;
-    for(String sr: input)  {
-        output.push_back(sr.getDoubleValue());
-    }  
+    for (String sr : input)
+    {
+        output.push_back (sr.getDoubleValue());
+    }
     return output;
 }
 
 std::vector<int> getBlockSizes (const ArgumentList& args)
 {
-    StringArray input = StringArray::fromTokens(getOptionValue (args, "--block-sizes", String ("64,128,256,512,1024") , "Missing block size list argument!").toString(),
-                                   ",",
-                                   "\""
-                                   );
+    StringArray input = StringArray::fromTokens (getOptionValue (args,
+                                                                 "--block-sizes",
+                                                                 String ("64,128,256,512,1024"),
+                                                                 "Missing block size list argument!")
+                                                     .toString(),
+                                                 ",",
+                                                 "\"");
     std::vector<int> output;
-    for(String sr: input)  {
-        output.push_back(sr.getIntValue());
-    }  
+    for (String sr : input)
+    {
+        output.push_back (sr.getIntValue());
+    }
     return output;
 }
 
@@ -249,7 +257,7 @@ static Option possibleOptions[] =
     { "--repeat",               true    },
     { "--randomise",            false   },
     { "--sample-rates",         true    },
-    { "--block-sizes",          true    }, 
+    { "--block-sizes",          true    },
 };
 
 StringArray mergeEnvironmentVariables (StringArray args, std::function<String (const String& name, const String& defaultValue)> environmentVariableProvider = [] (const String& name, const String& defaultValue) { return SystemStats::getEnvironmentVariable (name, defaultValue); })

--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -481,8 +481,8 @@ private:
             options.outputDir = File (v[IDs::outputDir].toString());
             options.withGUI = v.getProperty (IDs::withGUI, true);
             options.disabledTests = StringArray::fromLines (v.getProperty (IDs::disabledTests).toString());
-            options.sampleRates = juce::VariantConverter<std::vector<double>>::fromVar( v.getProperty (IDs::sampleRates) );
-            options.blockSizes  = juce::VariantConverter<std::vector<int>>::fromVar( v.getProperty (IDs::blockSizes) );
+            options.sampleRates = juce::VariantConverter<std::vector<double>>::fromVar (v.getProperty (IDs::sampleRates));
+            options.blockSizes = juce::VariantConverter<std::vector<int>>::fromVar (v.getProperty (IDs::blockSizes));
 
             for (auto c : v)
             {
@@ -674,8 +674,8 @@ private:
         v.setProperty (IDs::outputDir, options.outputDir.getFullPathName(), nullptr);
         v.setProperty (IDs::withGUI, options.withGUI, nullptr);
         v.setProperty (IDs::disabledTests, options.disabledTests.joinIntoString ("\n"), nullptr);
-        v.setProperty (IDs::sampleRates, juce::VariantConverter<std::vector<double>>::toVar(options.sampleRates), nullptr);
-        v.setProperty (IDs::blockSizes, juce::VariantConverter<std::vector<int>>::toVar(options.blockSizes), nullptr);
+        v.setProperty (IDs::sampleRates, juce::VariantConverter<std::vector<double>>::toVar (options.sampleRates), nullptr);
+        v.setProperty (IDs::blockSizes, juce::VariantConverter<std::vector<int>>::toVar (options.blockSizes), nullptr);
 
         return v;
     }

--- a/Source/Validator.cpp
+++ b/Source/Validator.cpp
@@ -481,9 +481,9 @@ private:
             options.outputDir = File (v[IDs::outputDir].toString());
             options.withGUI = v.getProperty (IDs::withGUI, true);
             options.disabledTests = StringArray::fromLines (v.getProperty (IDs::disabledTests).toString());
-            options.sampleRates = juce::VariantConverter<std::vector<double>>::fromVar( v.getProperty (IDs::sampleRates).toString() );
-            options.blockSizes  = juce::VariantConverter<std::vector<int>>::fromVar( v.getProperty (IDs::blockSizes).toString() );
-            
+            options.sampleRates = juce::VariantConverter<std::vector<double>>::fromVar( v.getProperty (IDs::sampleRates) );
+            options.blockSizes  = juce::VariantConverter<std::vector<int>>::fromVar( v.getProperty (IDs::blockSizes) );
+
             for (auto c : v)
             {
                 String fileOrID;

--- a/Source/Validator.h
+++ b/Source/Validator.h
@@ -27,28 +27,29 @@
 
 namespace juce
 {
-template<typename T>
+template <typename T>
 struct VariantConverter<std::vector<T>>
 {
     static std::vector<T> fromVar (const var& v)
     {
-        jassert (v.isArray());
-        Array<var>*    vr = v.getArray();
+        jassert (v.isString());
+
         std::vector<T> vc;
-        for (var vItem : *vr)
-        {
-            vc.push_back (static_cast<T> (vItem));
-        }
+
+        for (auto token : StringArray::fromTokens (v.toString(), ",", ""))
+            vc.push_back (static_cast<T> (var (token)));
+
         return vc;
     }
+
     static var toVar (const std::vector<T>& vc)
     {
-        juce::var vr;
-        for (T t : vc)
-        {
-            vr.append (t);
-        }
-        return vr;
+        if (vc.empty())
+            return "";
+
+        String text { vc.front() };
+        std::for_each (std::next (vc.begin()), vc.end(), [&] (const T& t) { text << ',' << t; });
+        return text;
     }
 };
 }// namespace juce

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -137,7 +137,7 @@ struct EditorWhilstProcessingTest   : public PluginTest
 
             const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
             const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
-            
+
             jassert (sampleRates.size()>0 && blockSizes.size()>0);
             instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
@@ -183,18 +183,18 @@ struct AudioProcessingTest  : public PluginTest
         : PluginTest ("Audio processing", 3)
     {
     }
-    
+
     static void runAudioProcessingTest (PluginTests& ut, AudioPluginInstance& instance,
                                         bool callReleaseResourcesBeforeSampleRateChange)
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
-        
+
         const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
         const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
-        
+
         jassert (sampleRates.size()>0 && blockSizes.size()>0);
         instance.prepareToPlay (sampleRates[0], blockSizes[0]);
-               
+
         const int numBlocks = 10;
         auto r = ut.getRandom();
 
@@ -203,12 +203,12 @@ struct AudioProcessingTest  : public PluginTest
             for (auto bs : blockSizes)
             {
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                               .replace ("SR", String(sr,0) , false)
-                            .replace ("BS", String(bs), false));
-                
+                                   .replace ("SR", String (sr, 0), false)
+                                   .replace ("BS", String (bs), false));
+
                 if (callReleaseResourcesBeforeSampleRateChange)
                     instance.releaseResources();
-                
+
                 instance.prepareToPlay (sr, bs);
 
                 const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
@@ -354,11 +354,11 @@ struct AutomationTest  : public PluginTest
     {
         const bool subnormalsAreErrors = ut.getOptions().strictnessLevel > 5;
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
-        
+
         const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
         const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
-        
-        jassert (sampleRates.size()>0 && blockSizes.size()>0);
+
+        jassert (sampleRates.size() > 0 && blockSizes.size() > 0);
         instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
         auto r = ut.getRandom();
@@ -369,9 +369,9 @@ struct AutomationTest  : public PluginTest
             {
                 const int subBlockSize = 32;
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS] and sub-block size [SB]")
-                            .replace ("SR", String(sr,0), false)
-                            .replace ("BS", String(bs), false)
-                            .replace ("SB", String (subBlockSize), false));
+                                   .replace ("SR", String (sr, 0), false)
+                                   .replace ("BS", String (bs), false)
+                                   .replace ("SB", String (subBlockSize), false));
 
                 instance.releaseResources();
                 instance.prepareToPlay (sr, bs);

--- a/Source/tests/ExtremeTests.cpp
+++ b/Source/tests/ExtremeTests.cpp
@@ -26,11 +26,11 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
     void runTest (PluginTests& ut, AudioPluginInstance& instance) override
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
- 
+
         const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
         const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
-        
-        jassert (sampleRates.size()>0 && blockSizes.size()>0);
+
+        jassert (sampleRates.size() > 0 && blockSizes.size() > 0);
         instance.prepareToPlay (sampleRates[0], blockSizes[0]);
 
         const int numBlocks = 10;
@@ -41,8 +41,8 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
             for (auto bs : blockSizes)
             {
                 ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                               .replace ("SR", String(sr,0), false)
-                               .replace ("BS", String(bs), false));
+                                   .replace ("SR", String (sr, 0), false)
+                                   .replace ("BS", String (bs), false));
                 instance.releaseResources();
                 instance.prepareToPlay (sr, bs);
 
@@ -108,21 +108,21 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
             ut.logMessage ("INFO: Skipping test for plugin format");
             return;
         }
-        
+
         const std::vector<double>& sampleRates = ut.getOptions().sampleRates;
         const std::vector<int>& blockSizes = ut.getOptions().blockSizes;
 
-        jassert (sampleRates.size()>0 && blockSizes.size()>0);
-        
+        jassert (sampleRates.size() > 0 && blockSizes.size() > 0);
+
         for (auto sr : sampleRates)
         {
             for (auto preparedBlockSize : blockSizes)
             {
                 const auto processingBlockSize = preparedBlockSize * 2;
                 ut.logMessage (String ("Preparing with sample rate [SR] and block size [BS], processing with block size [BSP]")
-                               .replace ("SR", String(sr,0), false)
-                               .replace ("BSP", String (processingBlockSize), false)
-                               .replace ("BS", String(preparedBlockSize), false));
+                                   .replace ("SR", String (sr, 0), false)
+                                   .replace ("BSP", String (processingBlockSize), false)
+                                   .replace ("BS", String (preparedBlockSize), false));
                 instance.releaseResources();
                 instance.prepareToPlay (sr, preparedBlockSize);
 


### PR DESCRIPTION
`pluginval` fails to validate plugins when built from develop. The cause seems to be some faulty var conversion code. This patch allows pluginval to validate plugins again, and also fixes some whitespace/formatting issues.