### PR TITLE
Update to JUCE 6.1.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,7 @@ target_compile_definitions(pluginval PRIVATE
     JUCE_WEB_BROWSER=0
     JUCER_ENABLE_GPL_MODE=1
     JUCE_DISPLAY_SPLASH_SCREEN=0
+    JUCE_MODAL_LOOPS_PERMITTED=1
     JUCE_REPORT_APP_USAGE=0)
 
 target_link_libraries(pluginval PRIVATE

--- a/pluginval.jucer
+++ b/pluginval.jucer
@@ -2,7 +2,7 @@
 
 <JUCERPROJECT name="pluginval" projectType="guiapp" id="IA2Ov0" version="0.2.9"
               companyName="Tracktion" headerPath="../../modules/juce/modules/juce_audio_processors/format_types/VST3_SDK&#10;../../VST3_SDK"
-              jucerFormatVersion="1">
+              jucerFormatVersion="1" defines="JUCE_PLUGINHOST_AU=1 JUCE_PLUGINHOST_VST3=1 JUCE_PLUGINHOST_LADSPA=1 JUCE_WEB_BROWSER=0 JUCE_USE_CURL=0 JUCE_MODAL_LOOPS_PERMITTED=1">
   <MAINGROUP id="zUhKLj" name="pluginval">
     <FILE id="gV5MZv" name="CHANGELIST.md" compile="0" resource="0" file="CHANGELIST.md"/>
     <GROUP id="{DF1CFAD6-E73F-2DAB-3957-D1F25BDD2E13}" name="Source">
@@ -118,5 +118,5 @@
     <MODULE id="juce_gui_extra" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>
   </MODULES>
   <JUCEOPTIONS JUCE_PLUGINHOST_AU="1" JUCE_PLUGINHOST_VST3="1" JUCE_PLUGINHOST_LADSPA="1"
-               JUCE_WEB_BROWSER="0" JUCE_USE_CURL="0"/>
+               JUCE_WEB_BROWSER="0" JUCE_USE_CURL="0" JUCE_MODAL_LOOPS_PERMITTED="1"/>
 </JUCERPROJECT>


### PR DESCRIPTION
This PR does the following:

1. Sets `JUCE_MODAL_LOOPS_PERMITTED=1` for CMake and the Projucer
2. Sets the JUCE submodule to point to [JUCE's 6.1.0 commit](https://github.com/juce-framework/JUCE/commit/4f01392000965f6c5e957329220d5ad06ca174c4)
3. Should close #44 once a linux build is made (making pluginval happy on github actions without compiling) 

I successfully built pluginval and ran a validation using both cmake and projucer builds on MacOS.

Note: I first tried adding `JUCE_MODAL_LOOPS_PERMITTED=1` manually to the jucer xml, but that didn't take. I reentered all preprocessor definitions into the projucer UI and saved and it added what seems to be a `defines` attribute to the `JUCERPROJECT` and everything seems to be happy.