### PR TITLE
Code sign fix and Notarization timeout increase

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
         
       - name: "Notarize (macOS)"
         if: ${{ matrix.name == 'macOS' }}
-        uses: sudara/xcode-notarize@v1
+        uses: sudara/xcode-notarize@main
         with:
           product-path: ${{ env.APP_DIR }}/pluginval.app
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -78,7 +78,7 @@ jobs:
           
       - name: Codesign (macOS)
         if: ${{ matrix.name == 'macOS' }}
-        run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/${{ matrix.binary}} --deep --strict --options=runtime --timestamp
+        run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/pluginval.app --deep --strict --options=runtime --timestamp
         
       - name: "Notarize (macOS)"
         if: ${{ matrix.name == 'macOS' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -82,11 +82,12 @@ jobs:
         
       - name: "Notarize (macOS)"
         if: ${{ matrix.name == 'macOS' }}
-        uses: devbotsxyz/xcode-notarize@v1
+        uses: sudara/xcode-notarize@v1
         with:
           product-path: ${{ env.APP_DIR }}/pluginval.app
           appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
           appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
+          number-of-status-check-attempts: 20
           
       - name: "Staple (macOS)"
         if: ${{ matrix.name == 'macOS' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -20,7 +20,7 @@ jobs:
             binary: ./pluginval
           - name: macOS
             os: macos-12
-            binary: pluginval.app/Contents/MacOS/pluginval
+            binary: pluginval.app
           - name: Windows
             os: windows-latest
             binary: ./pluginval.exe
@@ -93,7 +93,7 @@ jobs:
         if: ${{ matrix.name == 'macOS' }}
         uses: devbotsxyz/xcode-staple@v1
         with:
-          product-path: ${{ env.APP_DIR }}/pluginval.app
+          product-path: ${{ env.APP_DIR }}/${{ matrix.binary }}
       
       - name: Create zip files
         working-directory: ${{ env.APP_DIR }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,13 +17,16 @@ jobs:
         include:
           - name: Linux
             os: ubuntu-22.04
-            binary: ./pluginval
+            app: pluginval
+            test-binary: ./pluginval
           - name: macOS
             os: macos-12
-            binary: pluginval.app
+            app: pluginval.app
+            test-binary: pluginval.app/Contents/MacOS/pluginval
           - name: Windows
             os: windows-latest
-            binary: ./pluginval.exe
+            app: pluginval.exe
+            test-binary: ./pluginval.exe
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -74,11 +77,11 @@ jobs:
         run: |
           pwd
           ls -ahl
-          ${{ matrix.binary }} --run-tests
+          ${{ matrix.test-binary }} --run-tests
           
       - name: Codesign (macOS)
         if: ${{ matrix.name == 'macOS' }}
-        run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/pluginval.app --deep --strict --options=runtime --timestamp
+        run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/${{ matrix.app }} --deep --strict --options=runtime --timestamp
         
       - name: "Notarize (macOS)"
         if: ${{ matrix.name == 'macOS' }}
@@ -93,11 +96,11 @@ jobs:
         if: ${{ matrix.name == 'macOS' }}
         uses: devbotsxyz/xcode-staple@v1
         with:
-          product-path: ${{ env.APP_DIR }}/${{ matrix.binary }}
+          product-path: ${{ env.APP_DIR }}/pluginval.app
       
       - name: Create zip files
         working-directory: ${{ env.APP_DIR }}
-        run: cmake -E tar cfv ${{ env.ZIP_FILE_NAME }} --format=zip ${{ matrix.binary }}
+        run: cmake -E tar cfv ${{ env.ZIP_FILE_NAME }} --format=zip ${{ matrix.app }}
       
       - name: Upload zip files
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
This PR does two things:

1. FIxes the "can't open because it may be damaged or incomplete" macOS issue by signing and zipping the `.app` bundle (instead of the binary within it)
2. Doubles the notarization timeout to 20 x 30 seconds (up to 10 min) using my [xcode-notarize fork](http://github.com/sudara/xcode-notarize).