### PR TITLE
Use notarytool for notarization

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -90,15 +90,18 @@ jobs:
         if: ${{ matrix.name == 'macOS' }}
         run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/${{ matrix.app }} --deep --strict --options=runtime --timestamp
       
+      - name: "Notarize and staple (macOS)"
+        if: ${{ matrix.name == 'macOS' }}
+        working-directory: ${{ env.APP_DIR }}
+        run: |
+          7z a -tzip ${{ env.ZIP_FILE_NAME }} ${{ matrix.app }}
+          xcrun notarytool submit ${{ env.ZIP_FILE_NAME }} --apple-id ${{ secrets.NOTARIZATION_USERNAME }} --password ${{ secrets.NOTARIZATION_PASSWORD }} --team-id ${{ secrets.TEAM_ID }} --wait
+          xcrun stapler staple ${{ matrix.app }}
+          rm ${{ env.ZIP_FILE_NAME }}
+      
       - name: Create zip files
         working-directory: ${{ env.APP_DIR }}
-        run: cmake -E tar cfv ${{ env.ZIP_FILE_NAME }} --format=zip ${{ matrix.app }}
-      
-      - name: "Notarize and Staple (macOS)"
-        if: ${{ matrix.name == 'macOS' }}
-        run: |
-          xcrun notarytool submit ${{ env.APP_DIR }}/${{ env.ZIP_FILE_NAME }} --apple-id ${{ secrets.NOTARIZATION_USERNAME }} --password ${{ secrets.NOTARIZATION_PASSWORD }} --team-id ${{ secrets.TEAM_ID }} --wait
-          xcrun stapler staple ${{ env.APP_DIR }}/${{ env.ZIP_FILE_NAME }}
+        run: 7z a -aoa -tzip ${{ env.ZIP_FILE_NAME }} ${{ matrix.app }}
       
       - name: Upload zip files
         uses: actions/upload-artifact@v3

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,25 +89,16 @@ jobs:
       - name: Codesign (macOS)
         if: ${{ matrix.name == 'macOS' }}
         run: codesign --force -s "${{ secrets.DEVELOPER_ID_APPLICATION}}" -v ${{ env.APP_DIR }}/${{ matrix.app }} --deep --strict --options=runtime --timestamp
-        
-      - name: "Notarize (macOS)"
-        if: ${{ matrix.name == 'macOS' }}
-        uses: sudara/xcode-notarize@main
-        with:
-          product-path: ${{ env.APP_DIR }}/pluginval.app
-          appstore-connect-username: ${{ secrets.NOTARIZATION_USERNAME }}
-          appstore-connect-password: ${{ secrets.NOTARIZATION_PASSWORD }}
-          number-of-status-check-attempts: 20
-          
-      - name: "Staple (macOS)"
-        if: ${{ matrix.name == 'macOS' }}
-        uses: devbotsxyz/xcode-staple@v1
-        with:
-          product-path: ${{ env.APP_DIR }}/pluginval.app
       
       - name: Create zip files
         working-directory: ${{ env.APP_DIR }}
         run: cmake -E tar cfv ${{ env.ZIP_FILE_NAME }} --format=zip ${{ matrix.app }}
+      
+      - name: "Notarize and Staple (macOS)"
+        if: ${{ matrix.name == 'macOS' }}
+        run: |
+          xcrun notarytool submit ${{ env.APP_DIR }}/${{ env.ZIP_FILE_NAME }} --apple-id ${{ secrets.NOTARIZATION_USERNAME }} --password ${{ secrets.NOTARIZATION_PASSWORD }} --team-id ${{ secrets.TEAM_ID }} --wait
+          xcrun stapler staple ${{ env.APP_DIR }}/${{ env.ZIP_FILE_NAME }}
       
       - name: Upload zip files
         uses: actions/upload-artifact@v3


### PR DESCRIPTION
The current notarization method (`altool`) is deprecated and will be removed in 2023.

But good news: 

* Eyal tipped me off that the new `notarytool` is a one liner so we can get rid of the notarize action.  I replaced the staple action too, since that's a one liner.
* It's all-in-one command (handles the status waiting in the same command)
* It seems much faster (20-30s vs. 1.5-3+ min)
* I took the opportunity to get rid of cmake zipping to rely on 7z 

One caveat is that a zip (or pkg/dmg) file needs to be uploaded to `notarytool` — so I'm creating and removing a temp zip for this purpose. Not the most elegant, but I didn't want to assume a pkg/dmg was prefered.

I verified the [macOS executable is happy on my fork.](https://github.com/sudara/pluginval/actions/runs/2602776933)

BEFORE MERGE: 

One more secret needs to be added, the `TEAM_ID`. 

This is a subset of the `DEVELOPER_ID_APPLICATION` secret. For example if your string is `Developer ID Application: John Doe (6UPUNL91CN)`, then `TEAM_ID` is `6UPUNL91CN`. It can also be found in apple's [member center](https://developer.apple.com/account/#/membership) under membership details.