### PR TITLE
Clean up release action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,6 @@ name: Build
 on:
   workflow_dispatch:
   push:
-    branches:
-    tags:
-      - "v*"
 
 env:
   BINARY_NAME: pluginval
@@ -156,11 +153,11 @@ jobs:
       
   # Create release for tagged refs
   deploy:
-    if: startsWith(github.ref, 'refs/tags/')
+    if: contains(github.ref, 'tags/v')
     needs: build
     runs-on: ubuntu-latest
     steps:
-      
+      # Needed to grab CHANGELIST.md
       - uses: actions/checkout@v3
                 
       - name: Get Artifacts
@@ -170,18 +167,12 @@ jobs:
 
       - name: Display structure of downloaded files
         run: ls -la
-    
-      - name: Set tag name variable
-        shell: bash        
-        run: |
-          REF=${GITHUB_REF}
-          echo "TAG_NAME=${REF##*/}" >> $GITHUB_ENV
 
       - name: Create Release
         uses: softprops/action-gh-release@v1
         with:
-          tag_name: ${{ env.TAG_NAME }}
-          name: ${{ env.TAG_NAME }}
+          tag_name: ${{ github.ref }}
+          name: ${{ github.ref }}
           body_path: CHANGELIST.md
           draft: true
           files: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,7 +1,10 @@
 name: Build
 on:
-  push:
   workflow_dispatch:
+  push:
+    branches:
+    tags:
+      - "v*"
 
 env:
   BINARY_NAME: pluginval


### PR DESCRIPTION
This is just small cleanup. Uses `github.ref` and removes the manual step that does the same thing. 

I looked into merge commits and it's a bit messy on GitHub. 

A solution would be:

```yml
on:
  push:
    branches: # build every commit to these branches
      - master
      - develop
  pull_request:
    branches: # build every commit on every PR to these branches
      - master
      - develop
 ```

But on PRs from master to develop, it would double-build, and branches wouldn't build until a PR is opened. 