### PR TITLE
Fix quoted paths, relative paths, and option order dependence (+ tests) 

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           pwd
           ls -ahl
-          ${{ matrix.test-binary }} --run-tests --verbose
+          ${{ matrix.test-binary }} --run-tests
 
       - name: Cache JUCE example plugin binaries
         id: cache-plugins

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -89,7 +89,7 @@ jobs:
         run: |
           pwd
           ls -ahl
-          ${{ matrix.test-binary }} --run-tests
+          ${{ matrix.test-binary }} --run-tests --verbose
 
       - name: Cache JUCE example plugin binaries
         id: cache-plugins

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -409,8 +409,25 @@ static ArgumentList createCommandLineArgs (String commandLine)
                                                 || argList.containsOption ("--run-tests");
 
         if (! hasValidateOrOtherCommand)
-            if (isPluginArgument (argList.arguments.getLast().text))
-                argList.arguments.insert (argList.arguments.size() - 1, { "--validate" });
+        {
+            const auto lastArgument = argList.arguments.getLast().text;
+            if (isPluginArgument (lastArgument))
+            {
+              argList.removeOptionIfFound (lastArgument);
+              argList.arguments.insert (argList.arguments.size() - 1, { "--validate=" + lastArgument });
+            }
+
+        }
+        // JUCE console apps only parse long options (--something) when an equal sign is present
+        // So let's shim one in to allow people to omit it for compatibility
+        // As well as make our arguments position independent
+        else if (argList.containsOption ("--validate"))
+        {
+            const auto index = argList.indexOfOption ("--validate");
+            auto& fileOrID = argList.arguments.getReference (index + 1).text;
+            auto& validateOption = argList.arguments.getReference (index);
+            validateOption.text = "--validate=" + fileOrID;
+        }
     }
 
     return argList;
@@ -462,12 +479,7 @@ bool shouldPerformCommandLine (const String& commandLine)
 //==============================================================================
 std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::ArgumentList& args)
 {
-    // prioritize explicit arguments
     auto fileOrID = args.getValueForOption ("--validate");
-
-    // but let user lazily supply the plugin path as the last arg
-    if (fileOrID.isEmpty())
-        fileOrID = args.arguments.getLast().text;
 
     // in the case of a path (vs. ID), grab the full path
     // getCurrentWorkingDirectory is needed to handle relative paths

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -462,12 +462,7 @@ bool shouldPerformCommandLine (const String& commandLine)
 //==============================================================================
 std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::ArgumentList& args)
 {
-    // prioritize explicit arguments
-    auto fileOrID = args.getValueForOption ("--validate");
-
-    // but let user lazily supply the plugin path as the last arg
-    if (fileOrID.isEmpty())
-        fileOrID = args.arguments.getLast().text;
+    auto fileOrID = getOptionValue (args, "--validate", "", "Expected a plugin path for the --validate option").toString();
 
     // in the case of a path (vs. ID), grab the full path
     // getCurrentWorkingDirectory is needed to handle relative paths

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -69,7 +69,6 @@ struct CommandLineTests : public UnitTest
             expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), String ("/path/to/file"));
             expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), String ("/path/to/dir"));
             expectEquals (getOptionValue (args, "--validate", {}, "Missing validate argument!").toString(), String ("/path/to/plugin"));
-            expectEquals (parseCommandLine (args).first, String ("/path/to/plugin"));
         }
 
         beginTest ("Handles an absolute path to the plugin");
@@ -91,16 +90,16 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Handles a relative path");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto currentDir = File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs ("--validate MyPlugin.vst3");
-            expectEquals (parseCommandLine (args).first, currentDir + "/MyPlugin.vst3");
+            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
         }
 
-        beginTest ("Handles a quoted relative path to the plugin");
+        beginTest ("Handles a quoted relative path with spaces to the plugin");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto currentDir = File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs (R"(--validate "My Plugin.vst3")");
-            expectEquals (parseCommandLine (args).first, currentDir + "/My Plugin.vst3");
+            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("My Plugin.vst3").getFullPathName());
         }
 
         #if !JUCE_WINDOWS
@@ -130,9 +129,9 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Implicit validate with a relative path");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto currentDir = File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs ("MyPlugin.vst3");
-            expectEquals (parseCommandLine (args).first, currentDir + "/MyPlugin.vst3");
+            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
         }
 
         beginTest ("Doesn't alter component IDs");

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -127,14 +127,6 @@ struct CommandLineTests : public UnitTest
         }
         #endif
 
-        beginTest ("Allows for other options after explicit --validate");
-        {
-            const auto currentDir = File::getCurrentWorkingDirectory();
-            const auto args = createCommandLineArgs ("--validate MyPlugin.vst3 --randomise");
-            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
-            expect (parseCommandLine(args).second.randomiseTestOrder);
-        }
-
         beginTest ("Implicit validate with a relative path");
         {
             const auto currentDir = File::getCurrentWorkingDirectory();

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -22,7 +22,7 @@ struct CommandLineTests : public UnitTest
 
     void runTest() override
     {
-        
+
         beginTest ("Merge environment variables");
         {
             StringPairArray envVars;
@@ -61,13 +61,85 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Command line parser");
         {
-            ArgumentList args ({}, "--strictness-level 7 --random-seed 1234 --timeout-ms 20000 --repeat 11 --data-file <path_to_file> --output-dir <path_to_dir>");
+            ArgumentList args ({}, "--strictness-level 7 --random-seed 1234 --timeout-ms 20000 --repeat 11 --data-file /path/to/file --output-dir /path/to/dir --validate /path/to/plugin");
             expectEquals (getStrictnessLevel (args), 7);
             expectEquals (getRandomSeed (args), (int64) 1234);
             expectEquals (getTimeout (args), (int64) 20000);
             expectEquals (getNumRepeats (args), 11);
-            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), String ("<path_to_file>"));
-            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), String ("<path_to_dir>"));
+            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), String ("/path/to/file"));
+            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), String ("/path/to/dir"));
+            expectEquals (getOptionValue (args, "--validate", {}, "Missing validate argument!").toString(), String ("/path/to/plugin"));
+            expectEquals (parseCommandLine (args).first, String ("/path/to/plugin"));
+        }
+
+        beginTest ("Handles an absolute path to the plugin");
+        {
+            const auto homeDir = File::getSpecialLocation (File::userHomeDirectory).getFullPathName();
+            const auto commandLineString = "--validate " + homeDir + "/path/to/MyPlugin";
+            const auto args = createCommandLineArgs (commandLineString);
+            expectEquals (parseCommandLine (args).first, homeDir + "/path/to/MyPlugin");
+        }
+
+        beginTest ("Handles a quoted absolute path to the plugin");
+        {
+            const auto homeDir = File::getSpecialLocation (File::userHomeDirectory).getFullPathName();
+            const auto pathToQuote = homeDir + "/path/to/MyPlugin";
+            const auto commandLineString = "--validate " + pathToQuote.quoted();
+            const auto args = createCommandLineArgs (commandLineString);
+            expectEquals (parseCommandLine (args).first, homeDir + "/path/to/MyPlugin");
+        }
+
+        beginTest ("Handles a relative path");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto args = createCommandLineArgs ("--validate MyPlugin.vst3");
+            expectEquals (parseCommandLine (args).first, currentDir + "/MyPlugin.vst3");
+        }
+
+        beginTest ("Handles a quoted relative path to the plugin");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto args = createCommandLineArgs (R"(--validate "My Plugin.vst3")");
+            expectEquals (parseCommandLine (args).first, currentDir + "/My Plugin.vst3");
+        }
+
+        #if !JUCE_WINDOWS
+
+        beginTest ("Handles a relative path with ./ to the plugin");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto commandLineString = "--validate ./path/to/MyPlugin";
+            const auto args = createCommandLineArgs(commandLineString);
+            expectEquals (parseCommandLine (args).first, currentDir + "/path/to/MyPlugin");
+        }
+
+        beginTest ("Handles a home directory relative path to the plugin");
+        {
+            const auto commandLineString = "--validate ~/path/to/MyPlugin";
+            const auto args = createCommandLineArgs(commandLineString);
+            expectEquals (parseCommandLine (args).first, File::getSpecialLocation (File::userHomeDirectory).getFullPathName() + "/path/to/MyPlugin");
+        }
+
+        beginTest ("Handles quoted strings, spaces, and home directory relative path to the plugin");
+        {
+            const auto commandLineString = R"(--data-file "~/path/to/My File" --output-dir "~/path/to/My Directory" --validate "~/path/to/My Plugin")";
+            const auto args = createCommandLineArgs(commandLineString);
+            expectEquals (parseCommandLine (args).first, File::getSpecialLocation (File::userHomeDirectory).getFullPathName() + "/path/to/My Plugin");
+        }
+        #endif
+
+        beginTest ("Implicit validate with a relative path");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto args = createCommandLineArgs ("MyPlugin.vst3");
+            expectEquals (parseCommandLine (args).first, currentDir + "/MyPlugin.vst3");
+        }
+
+        beginTest ("Doesn't alter component IDs");
+        {
+            const auto commandLineString = "--validate MyPluginID";
+            const auto args = createCommandLineArgs(commandLineString);
+            expectEquals (parseCommandLine (args).first, String ("MyPluginID"));
         }
 
         beginTest ("Command line random");

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -127,6 +127,14 @@ struct CommandLineTests : public UnitTest
         }
         #endif
 
+        beginTest ("Allows for other options after explicit --validate");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto args = createCommandLineArgs ("--validate MyPlugin.vst3 --randomise");
+            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
+            expect (parseCommandLine(args).second.randomiseTestOrder);
+        }
+
         beginTest ("Implicit validate with a relative path");
         {
             const auto currentDir = File::getCurrentWorkingDirectory();

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -153,6 +153,14 @@ struct CommandLineTests : public UnitTest
             expect (temp.getFile().create());
             expect (shouldPerformCommandLine (temp.getFile().getFullPathName()));
         }
+
+        beginTest ("Allows for other options after explicit --validate");
+        {
+            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto args = createCommandLineArgs ("--validate MyPlugin.vst3 --randomise");
+            expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
+            expect (parseCommandLine(args).second.randomiseTestOrder);
+        }
     }
 };
 

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -95,6 +95,7 @@ void PluginTests::runTest()
     {
         beginTest ("Scan for plugins located in: " + fileOrID);
         WaitableEvent completionEvent;
+
         MessageManager::callAsync ([&, this]() mutable
                                    {
                                        knownPluginList.scanAndAddDragAndDroppedFiles (formatManager, StringArray (fileOrID), typesFound);

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -94,8 +94,8 @@ void PluginTests::runTest()
     if (fileOrID.isNotEmpty())
     {
         beginTest ("Scan for plugins located in: " + fileOrID);
-        WaitableEvent completionEvent;
 
+        WaitableEvent completionEvent;
         MessageManager::callAsync ([&, this]() mutable
                                    {
                                        knownPluginList.scanAndAddDragAndDroppedFiles (formatManager, StringArray (fileOrID), typesFound);

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -94,7 +94,6 @@ void PluginTests::runTest()
     if (fileOrID.isNotEmpty())
     {
         beginTest ("Scan for plugins located in: " + fileOrID);
-
         WaitableEvent completionEvent;
         MessageManager::callAsync ([&, this]() mutable
                                    {

--- a/Source/Validator.h
+++ b/Source/Validator.h
@@ -32,7 +32,7 @@ enum class ValidationType
 
 //==============================================================================
 /**
-    A single, asyncronouse validation pass for a specific plugin.
+    A single, asynchronous validation pass for a specific plugin.
 */
 class ValidationPass
 {


### PR DESCRIPTION
Closes #79.

Waiting to go green here: https://github.com/sudara/pluginval/actions/runs/2720056546

Quoting paths to `--validate` doesn't work in 1.0, so the following fail, making it hard to work with filenames with spaces:

```
# Quoted relative paths 
pluginval --validate "~/Library/Audio/Plug-Ins/Components/Plugin.component"         
pluginval --validate "~/Library/Audio/Plug-Ins/Components/Sine Machine.component"         

# Quoted absolute paths
pluginval --validate "/Users/sudara/Library/Audio/Components/Sine Machine.component"
```

I think a few other relative path edge cases were failing too, but I don't quite remember now. The `fileOrID` variable wasn't being used in `parseCommandLine`'s return value. 

I followed [the best practice as described in this assert](https://github.com/juce-framework/JUCE/blob/master/modules/juce_core/files/juce_File.cpp#L200-L207) for constructing relative paths and added tests for many permutations of paths and ids.

Note:  `--run-tests` doesn't produce seem any test output on Windows pluginval 1.0 (beyond logging the # failed), so it's a bit tough to debug test failures there at the moment.