### PR TITLE
Output timing info to verbose log, support snapshot testing

### DIFF
--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -88,7 +88,7 @@ void PluginTests::runTest()
     // This has to be called on a background thread to keep the message thread free
     jassert (! juce::MessageManager::existsAndIsCurrentThread());
 
-    logMessage ("Validation started: " + Time::getCurrentTime().toString (true, true) + "\n");
+    logVerboseMessage ("Validation started: " + Time::getCurrentTime().toString (true, true) + "\n");
     logMessage ("Strictness level: " + String (options.strictnessLevel));
 
     if (fileOrID.isNotEmpty())
@@ -133,7 +133,7 @@ void PluginTests::testType (const PluginDescription& pd)
         beginTest ("Open plugin (cold)");
         StopwatchTimer sw;
         deletePluginAsync (testOpenPlugin (pd));
-        logMessage ("\nTime taken to open plugin (cold): " + sw.getDescription());
+        logVerboseMessage ("\nTime taken to open plugin (cold): " + sw.getDescription());
     }
 
     {
@@ -142,7 +142,7 @@ void PluginTests::testType (const PluginDescription& pd)
 
         if (auto instance = testOpenPlugin (pd))
         {
-            logMessage ("\nTime taken to open plugin (warm): " + sw.getDescription());
+            logVerboseMessage ("\nTime taken to open plugin (warm): " + sw.getDescription());
             logMessage (String ("Running tests 123 times").replace ("123", String (options.numRepeats)));
 
             // This sleep is here to allow time for plugin async initialisation as in most cases
@@ -198,7 +198,7 @@ void PluginTests::testType (const PluginDescription& pd)
                         t->runTest (*this, *instance);
                     }
 
-                    logMessage ("\nTime taken to run test: " + sw2.getDescription());
+                    logVerboseMessage ("\nTime taken to run test: " + sw2.getDescription());
                 }
             }
 
@@ -206,5 +206,5 @@ void PluginTests::testType (const PluginDescription& pd)
         }
     }
 
-    logMessage ("\nTime taken to run all tests: " + totalTimer.getDescription());
+    logVerboseMessage ("\nTime taken to run all tests: " + totalTimer.getDescription());
 }

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -88,7 +88,8 @@ void PluginTests::runTest()
     // This has to be called on a background thread to keep the message thread free
     jassert (! juce::MessageManager::existsAndIsCurrentThread());
 
-    logVerboseMessage ("Validation started: " + Time::getCurrentTime().toString (true, true) + "\n");
+    logMessage ("Validation started");
+    logVerboseMessage ("\t" + Time::getCurrentTime().toString (true, true) + "\n");
     logMessage ("Strictness level: " + String (options.strictnessLevel));
 
     if (fileOrID.isNotEmpty())

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -105,14 +105,14 @@ struct EditorTest   : public PluginTest
             {
                 ScopedEditorShower editorShower (instance);
                 ut.expect (editorShower.editor != nullptr, "Unable to create editor");
-                ut.logMessage ("\nTime taken to open editor (cold): " + timer.getDescription());
+                ut.logVerboseMessage ("\nTime taken to open editor (cold): " + timer.getDescription());
             }
 
             {
                 timer.reset();
                 ScopedEditorShower editorShower (instance);
                 ut.expect (editorShower.editor != nullptr, "Unable to create editor on second attempt");
-                ut.logMessage ("Time taken to open editor (warm): " + timer.getDescription());
+                ut.logVerboseMessage ("Time taken to open editor (warm): " + timer.getDescription());
             }
         }
     }


### PR DESCRIPTION
Fixes #71

When testing the output of pluginval using snapshot testing, there are differences in date/times on each run (even though using the same binary and plugin file). This breaks snapshot testing as it expects the same output from the same input. The only way around current functionality, is to manually parse the output and remove the date/times manually from each run. pretty hacky.

This PR moves timing info to only output in the verbose log. These are the lines moved to verbose output:
```
Validation started: 10 Jul 2022 2:54:09pm
Time taken to open plugin (cold): 243 ms
Time taken to open plugin (warm): 126 ms
Time taken to open editor (cold): 504 ms
Time taken to open editor (warm): 510 ms
Time taken to run test: 678 ms
```

With this change applied, every run of pluginval outputs the same results from the same input. This enables snapshot testing and a reproducible output each time.