### PR TITLE
Remove JuceHeader.h and qualify with juce:: namespace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,7 @@ install/testresults.txt
 **/bin
 **/tmp
 **/cmake_build
+
+# CLion
+cmake-build*
+.idea/

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -24,17 +24,17 @@
 
 
 //==============================================================================
-static void exitWithError (const String& error)
+static void exitWithError (const juce::String& error)
 {
     std::cout << error << std::endl << std::endl;
-    JUCEApplication::getInstance()->setApplicationReturnValue (1);
-    JUCEApplication::getInstance()->quit();
+    juce::JUCEApplication::getInstance()->setApplicationReturnValue (1);
+    juce::JUCEApplication::getInstance()->quit();
 }
 
 static void hideDockIcon()
 {
    #if JUCE_MAC
-    Process::setDockIconVisible (false);
+     juce::Process::setDockIconVisible (false);
    #endif
 }
 
@@ -49,7 +49,7 @@ static void setupSignalHandling()
 {
     const int signals[] = { SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGABRT };
 
-    for (int i = 0; i < numElementsInArray (signals); ++i)
+    for (int i = 0; i < juce::numElementsInArray (signals); ++i)
     {
         ::signal (signals[i], killWithoutMercy);
         ::siginterrupt (signals[i], 1);
@@ -83,7 +83,7 @@ void CommandLineValidator::validate (const juce::String& fileOrID, PluginTests::
                                                       if (exitCode > 0)
                                                           exitWithError ("*** FAILED");
                                                       else
-                                                          JUCEApplication::getInstance()->quit();
+                                                          juce::JUCEApplication::getInstance()->quit();
                                                   },
                                                   [] (auto m)
                                                   {
@@ -96,7 +96,7 @@ void CommandLineValidator::validate (const juce::String& fileOrID, PluginTests::
 //==============================================================================
 namespace
 {
-    ArgumentList::Argument getArgumentAfterOption (const ArgumentList& args, StringRef option)
+    juce::ArgumentList::Argument getArgumentAfterOption (const juce::ArgumentList& args, juce::StringRef option)
     {
         for (int i = 0; i < args.size() - 1; ++i)
             if (args[i] == option)
@@ -105,14 +105,14 @@ namespace
         return {};
     }
 
-    var getOptionValue (const ArgumentList& args, StringRef option, var defaultValue, StringRef errorMessage)
+    juce::var getOptionValue (const juce::ArgumentList& args, juce::StringRef option, juce::var defaultValue, juce::StringRef errorMessage)
     {
         if (args.containsOption (option))
         {
             const auto nextArg = getArgumentAfterOption (args, option);
 
             if (nextArg.isShortOption() || nextArg.isLongOption())
-                ConsoleApplication::fail (errorMessage, -1);
+                juce::ConsoleApplication::fail (errorMessage, -1);
 
             return nextArg.text;
         }
@@ -120,17 +120,17 @@ namespace
         return defaultValue;
     }
 
-    int getStrictnessLevel (const ArgumentList& args)
+    int getStrictnessLevel (const juce::ArgumentList& args)
     {
-        return jlimit (1, 10, (int) getOptionValue (args, "--strictness-level", 5, "Missing strictness level argument! (Must be between 1 - 10)"));
+        return juce::jlimit (1, 10, (int) getOptionValue (args, "--strictness-level", 5, "Missing strictness level argument! (Must be between 1 - 10)"));
     }
 
-    int64 getRandomSeed (const ArgumentList& args)
+    juce::int64 getRandomSeed (const juce::ArgumentList& args)
     {
-        const String seedString = getOptionValue (args, "--random-seed", "0", "Missing random seed argument!").toString();
+        const juce::String seedString = getOptionValue (args, "--random-seed", "0", "Missing random seed argument!").toString();
 
         if (! seedString.containsOnly ("x-0123456789acbdef"))
-            ConsoleApplication::fail ("Invalid random seed argument!", -1);
+            juce::ConsoleApplication::fail ("Invalid random seed argument!", -1);
 
         if (seedString.startsWith ("0x"))
             return seedString.getHexValue64();
@@ -138,61 +138,61 @@ namespace
         return seedString.getLargeIntValue();
     }
 
-    int64 getTimeout (const ArgumentList& args)
+    juce::int64 getTimeout (const juce::ArgumentList& args)
     {
         return getOptionValue (args, "--timeout-ms", 30000, "Missing timeout-ms level argument!");
     }
 
-    int getNumRepeats (const ArgumentList& args)
+    int getNumRepeats (const juce::ArgumentList& args)
     {
-        return jmax (1, (int) getOptionValue (args, "--repeat", 1, "Missing repeat argument! (Must be greater than 0)"));
+        return juce::jmax (1, (int) getOptionValue (args, "--repeat", 1, "Missing repeat argument! (Must be greater than 0)"));
     }
 
-    File getDataFile (const ArgumentList& args)
+    juce::File getDataFile (const juce::ArgumentList& args)
     {
         return getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString();
     }
 
-    File getOutputDir (const ArgumentList& args)
+    juce::File getOutputDir (const juce::ArgumentList& args)
     {
         return getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString();
     }
 
-    std::vector<double> getSampleRates (const ArgumentList& args)
+    std::vector<double> getSampleRates (const juce::ArgumentList& args)
     {
-        StringArray input = StringArray::fromTokens (getOptionValue (args,
+        juce::StringArray input = juce::StringArray::fromTokens (getOptionValue (args,
                                                                      "--sample-rates",
-                                                                     String ("44100,48000,96000"),
+                                                                    juce::String ("44100,48000,96000"),
                                                                      "Missing sample rate list argument!")
                                                          .toString(),
                                                      ",",
                                                      "\"");
         std::vector<double> output;
 
-        for (String sr : input)
+        for (juce::String sr : input)
             output.push_back (sr.getDoubleValue());
 
         return output;
     }
 
-    std::vector<int> getBlockSizes (const ArgumentList& args)
+    std::vector<int> getBlockSizes (const juce::ArgumentList& args)
     {
-        StringArray input = StringArray::fromTokens (getOptionValue (args,
+        juce::StringArray input = juce::StringArray::fromTokens (getOptionValue (args,
                                                                      "--block-sizes",
-                                                                     String ("64,128,256,512,1024"),
+                                                                    juce::String ("64,128,256,512,1024"),
                                                                      "Missing block size list argument!")
                                                          .toString(),
                                                      ",",
                                                      "\"");
         std::vector<int> output;
 
-        for (String sr : input)
+        for (juce::String sr : input)
             output.push_back (sr.getIntValue());
 
         return output;
     }
 
-    StringArray getDisabledTests (const ArgumentList& args)
+    juce::StringArray getDisabledTests (const juce::ArgumentList& args)
     {
         const auto value = getOptionValue (args, "--disabled-tests", {}, "Missing disabled-tests path argument!").toString();
 
@@ -219,7 +219,7 @@ namespace
                 return true;
 
         // The above will check if the file actually exists which isn't really what we want for CLI parsing
-        if (auto f = File::createFileWithoutCheckingPath (arg);
+        if (auto f = juce::File::createFileWithoutCheckingPath (arg);
             f.hasFileExtension (".vst3")
            #if JUCE_PLUGINHOST_VST
             || f.hasFileExtension (".dll")
@@ -238,9 +238,9 @@ struct Option
     bool requiresValue;
 };
 
-static String getEnvironmentVariableName (Option opt)
+static juce::String getEnvironmentVariableName (Option opt)
 {
-    return String (opt.name).trimCharactersAtStart ("-").replace ("-", "_").toUpperCase();
+    return juce::String (opt.name).trimCharactersAtStart ("-").replace ("-", "_").toUpperCase();
 }
 
 static Option possibleOptions[] =
@@ -259,7 +259,7 @@ static Option possibleOptions[] =
     { "--vst3validator",        true    },
 };
 
-static StringArray mergeEnvironmentVariables (StringArray args, std::function<String (const String& name, const String& defaultValue)> environmentVariableProvider = [] (const String& name, const String& defaultValue) { return SystemStats::getEnvironmentVariable (name, defaultValue); })
+static juce::StringArray mergeEnvironmentVariables (juce::StringArray args, std::function<juce::String (const juce::String& name, const juce::String& defaultValue)> environmentVariableProvider = [] (const juce::String& name, const juce::String& defaultValue) { return juce::SystemStats::getEnvironmentVariable (name, defaultValue); })
 {
     for (auto arg : possibleOptions)
     {
@@ -289,14 +289,15 @@ static StringArray mergeEnvironmentVariables (StringArray args, std::function<St
 
 //==============================================================================
 //==============================================================================
-static String getHelpMessage()
+static juce::String getHelpMessage()
 {
-    const String appName (JUCEApplication::getInstance()->getApplicationName());
+    const juce::String appName (juce::JUCEApplication::getInstance()->getApplicationName());
 
-    String help;
+    auto& newLine = juce::newLine;
+    juce::String help;
     help << "//==============================================================================" << newLine
          << appName << newLine
-         << SystemStats::getJUCEVersion() << newLine
+         << juce::SystemStats::getJUCEVersion() << newLine
          << newLine
          << "Description: " << newLine
          << "  Validate plugins to test compatibility with hosts and verify plugin API conformance" << newLine << newLine
@@ -348,12 +349,12 @@ static String getHelpMessage()
     return help;
 }
 
-static String getVersionText()
+static juce::String getVersionText()
 {
-    return String (ProjectInfo::projectName) + " - " + ProjectInfo::versionString;
+    return juce::String ("pluginval") + " - " + VERSION;
 }
 
-static int getNumTestFailures (UnitTestRunner& testRunner)
+static int getNumTestFailures (juce::UnitTestRunner& testRunner)
 {
     int numFailures = 0;
 
@@ -366,16 +367,16 @@ static int getNumTestFailures (UnitTestRunner& testRunner)
 
 static void runUnitTests()
 {
-    UnitTestRunner testRunner;
+    juce::UnitTestRunner testRunner;
     testRunner.runTestsInCategory ("pluginval");
     const int numFailures = getNumTestFailures (testRunner);
 
     if (numFailures > 0)
-        ConsoleApplication::fail (String (numFailures) + " tests failed!!!");
+        juce::ConsoleApplication::fail (juce::String (numFailures) + " tests failed!!!");
 }
 
 //==============================================================================
-static ArgumentList createCommandLineArgs (String commandLine)
+static juce::ArgumentList createCommandLineArgs (juce::String commandLine)
 {
     if (commandLine.contains ("strictnessLevel"))
     {
@@ -387,9 +388,9 @@ static ArgumentList createCommandLineArgs (String commandLine)
                              .replace ("-NSDocumentRevisionsDebugMode YES", "")
                              .trim();
 
-    const auto exe = File::getSpecialLocation (File::currentExecutableFile);
+    const auto exe = juce::File::getSpecialLocation (juce::File::currentExecutableFile);
 
-    StringArray args;
+    juce::StringArray args;
     args.addTokens (commandLine, true);
     args = mergeEnvironmentVariables (args);
     args.trim();
@@ -399,7 +400,7 @@ static ArgumentList createCommandLineArgs (String commandLine)
 
     // If only a plugin path is supplied as the last arg, add an implicit --validate
     // option for it so the rest of the CLI works
-    ArgumentList argList (exe.getFullPathName(), args);
+    juce::ArgumentList argList (exe.getFullPathName(), args);
 
     if (argList.size() > 0)
     {
@@ -416,16 +417,16 @@ static ArgumentList createCommandLineArgs (String commandLine)
     return argList;
 }
 
-static void performCommandLine (CommandLineValidator& validator, const ArgumentList& args)
+static void performCommandLine (CommandLineValidator& validator, const juce::ArgumentList& args)
 {
     hideDockIcon();
 
-    ConsoleApplication cli;
+    juce::ConsoleApplication cli;
     cli.addVersionCommand ("--version", getVersionText());
     cli.addHelpCommand ("--help|-h", getHelpMessage(), true);
     cli.addCommand ({ "--validate",
                       "--validate [pathToPlugin]",
-                      "Validates the file (or IDs for AUs).", String(),
+                      "Validates the file (or IDs for AUs).", juce::String(),
                       [&validator] (const auto& validatorArgs)
                       {
                           auto [fileOrIDToValidate, options] = parseCommandLine (validatorArgs);
@@ -433,27 +434,27 @@ static void performCommandLine (CommandLineValidator& validator, const ArgumentL
                       }});
     cli.addCommand ({ "--run-tests",
                       "--run-tests",
-                      "Runs the internal unit tests.", String(),
+                      "Runs the internal unit tests.", juce::String(),
                       [] (const auto&) { runUnitTests(); }});
 
     if (const auto retValue = cli.findAndRunCommand (args); retValue != 0)
     {
-        JUCEApplication::getInstance()->setApplicationReturnValue (retValue);
-        JUCEApplication::getInstance()->quit();
+        juce::JUCEApplication::getInstance()->setApplicationReturnValue (retValue);
+        juce::JUCEApplication::getInstance()->quit();
     }
 
     // --validate runs async so will quit itself when done
     if (! args.containsOption ("--validate"))
-        JUCEApplication::getInstance()->quit();
+        juce::JUCEApplication::getInstance()->quit();
 }
 
 //==============================================================================
-void performCommandLine (CommandLineValidator& validator, const String& commandLine)
+void performCommandLine (CommandLineValidator& validator, const juce::String& commandLine)
 {
     performCommandLine (validator, createCommandLineArgs (commandLine));
 }
 
-bool shouldPerformCommandLine (const String& commandLine)
+bool shouldPerformCommandLine (const juce::String& commandLine)
 {
     const auto args = createCommandLineArgs (commandLine);
     return args.containsOption ("--help|-h")
@@ -472,7 +473,7 @@ std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::Argu
     // getCurrentWorkingDirectory is needed to handle relative paths
     // It preserves absolute paths and first checks for ~ on Mac/Windows
     if (fileOrID.contains ("~") || fileOrID.contains ("."))
-        fileOrID = File::getCurrentWorkingDirectory().getChildFile(fileOrID).getFullPathName();
+        fileOrID = juce::File::getCurrentWorkingDirectory().getChildFile(fileOrID).getFullPathName();
 
     PluginTests::Options options;
     options.strictnessLevel     = getStrictnessLevel (args);
@@ -492,7 +493,7 @@ std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::Argu
     return { fileOrID, options };
 }
 
-std::pair<juce::String, PluginTests::Options> parseCommandLine (const String& cmd)
+std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::String& cmd)
 {
     return parseCommandLine (createCommandLineArgs (cmd));
 }

--- a/Source/CommandLine.h
+++ b/Source/CommandLine.h
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_core/juce_core.h"
 #include "Validator.h"
 
 //==============================================================================
@@ -30,8 +30,8 @@ private:
 };
 
 //==============================================================================
-void performCommandLine (CommandLineValidator&, const String& commandLine);
-bool shouldPerformCommandLine (const String& commandLine);
+void performCommandLine (CommandLineValidator&, const juce::String& commandLine);
+bool shouldPerformCommandLine (const juce::String& commandLine);
 
 //==============================================================================
 std::pair<juce::String, PluginTests::Options> parseCommandLine (const juce::String&);

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -13,10 +13,10 @@
  ==============================================================================*/
 
 
-struct CommandLineTests : public UnitTest
+struct CommandLineTests : public juce::UnitTest
 {
     CommandLineTests()
-        : UnitTest ("CommandLineTests", "pluginval")
+        : juce::UnitTest ("CommandLineTests", "pluginval")
     {
     }
 
@@ -25,7 +25,7 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Merge environment variables");
         {
-            StringPairArray envVars;
+            juce::StringPairArray envVars;
             envVars.set ("STRICTNESS_LEVEL", "5");
             envVars.set ("RANDOM_SEED", "1234");
             envVars.set ("TIMEOUT_MS", "30000");
@@ -36,7 +36,7 @@ struct CommandLineTests : public UnitTest
             envVars.set ("DATA_FILE", "<path_to_file>");
             envVars.set ("OUTPUT_DIR", "<path_to_dir>");
 
-            const auto merged = mergeEnvironmentVariables (String(), [&envVars] (const String& n, const String& def) { return envVars.getValue (n, def); }).joinIntoString (" ");
+            const auto merged = mergeEnvironmentVariables (juce::String(), [&envVars] (const juce::String& n, const juce::String& def) { return envVars.getValue (n, def); }).joinIntoString (" ");
             expect (merged.contains ("--strictness-level 5"));
             expect (merged.contains ("--random-seed 1234"));
             expect (merged.contains ("--timeout-ms 30000"));
@@ -50,30 +50,30 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Command line defaults");
         {
-            ArgumentList args ({}, "");
+            juce::ArgumentList args ({}, "");
             expectEquals (getStrictnessLevel (args), 5);
-            expectEquals (getRandomSeed (args), (int64) 0);
-            expectEquals (getTimeout (args), (int64) 30000);
+            expectEquals (getRandomSeed (args), (juce::int64) 0);
+            expectEquals (getTimeout (args), (juce::int64) 30000);
             expectEquals (getNumRepeats (args), 1);
-            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), String());
-            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), String());
+            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), juce::String());
+            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), juce::String());
         }
 
         beginTest ("Command line parser");
         {
-            ArgumentList args ({}, "--strictness-level 7 --random-seed 1234 --timeout-ms 20000 --repeat 11 --data-file /path/to/file --output-dir /path/to/dir --validate /path/to/plugin");
+            juce::ArgumentList args ({}, "--strictness-level 7 --random-seed 1234 --timeout-ms 20000 --repeat 11 --data-file /path/to/file --output-dir /path/to/dir --validate /path/to/plugin");
             expectEquals (getStrictnessLevel (args), 7);
-            expectEquals (getRandomSeed (args), (int64) 1234);
-            expectEquals (getTimeout (args), (int64) 20000);
+            expectEquals (getRandomSeed (args), (juce::int64) 1234);
+            expectEquals (getTimeout (args), (juce::int64) 20000);
             expectEquals (getNumRepeats (args), 11);
-            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(), String ("/path/to/file"));
-            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(), String ("/path/to/dir"));
-            expectEquals (getOptionValue (args, "--validate", {}, "Missing validate argument!").toString(), String ("/path/to/plugin"));
+            expectEquals (getOptionValue (args, "--data-file", {}, "Missing data-file path argument!").toString(),juce::String ("/path/to/file"));
+            expectEquals (getOptionValue (args, "--output-dir", {}, "Missing output-dir path argument!").toString(),juce::String ("/path/to/dir"));
+            expectEquals (getOptionValue (args, "--validate", {}, "Missing validate argument!").toString(),juce::String ("/path/to/plugin"));
         }
 
         beginTest ("Handles an absolute path to the plugin");
         {
-            const auto homeDir = File::getSpecialLocation (File::userHomeDirectory).getFullPathName();
+            const auto homeDir = juce::File::getSpecialLocation (juce::File::userHomeDirectory).getFullPathName();
             const auto commandLineString = "--validate " + homeDir + "/path/to/MyPlugin";
             const auto args = createCommandLineArgs (commandLineString);
             expectEquals (parseCommandLine (args).first, homeDir + "/path/to/MyPlugin");
@@ -81,7 +81,7 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Handles a quoted absolute path to the plugin");
         {
-            const auto homeDir = File::getSpecialLocation (File::userHomeDirectory).getFullPathName();
+            const auto homeDir = juce::File::getSpecialLocation (juce::File::userHomeDirectory).getFullPathName();
             const auto pathToQuote = homeDir + "/path/to/MyPlugin";
             const auto commandLineString = "--validate " + pathToQuote.quoted();
             const auto args = createCommandLineArgs (commandLineString);
@@ -90,14 +90,14 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Handles a relative path");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs ("--validate MyPlugin.vst3");
             expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
         }
 
         beginTest ("Handles a quoted relative path with spaces to the plugin");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs (R"(--validate "My Plugin.vst3")");
             expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("My Plugin.vst3").getFullPathName());
         }
@@ -106,7 +106,7 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Handles a relative path with ./ to the plugin");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory().getFullPathName();
+            const auto currentDir = juce::File::getCurrentWorkingDirectory().getFullPathName();
             const auto commandLineString = "--validate ./path/to/MyPlugin";
             const auto args = createCommandLineArgs(commandLineString);
             expectEquals (parseCommandLine (args).first, currentDir + "/path/to/MyPlugin");
@@ -116,20 +116,20 @@ struct CommandLineTests : public UnitTest
         {
             const auto commandLineString = "--validate ~/path/to/MyPlugin";
             const auto args = createCommandLineArgs(commandLineString);
-            expectEquals (parseCommandLine (args).first, File::getSpecialLocation (File::userHomeDirectory).getFullPathName() + "/path/to/MyPlugin");
+            expectEquals (parseCommandLine (args).first, juce::File::getSpecialLocation (juce::File::userHomeDirectory).getFullPathName() + "/path/to/MyPlugin");
         }
 
         beginTest ("Handles quoted strings, spaces, and home directory relative path to the plugin");
         {
             const auto commandLineString = R"(--data-file "~/path/to/My File" --output-dir "~/path/to/My Directory" --validate "~/path/to/My Plugin")";
             const auto args = createCommandLineArgs(commandLineString);
-            expectEquals (parseCommandLine (args).first, File::getSpecialLocation (File::userHomeDirectory).getFullPathName() + "/path/to/My Plugin");
+            expectEquals (parseCommandLine (args).first, juce::File::getSpecialLocation (juce::File::userHomeDirectory).getFullPathName() + "/path/to/My Plugin");
         }
         #endif
 
         beginTest ("Implicit validate with a relative path");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs ("MyPlugin.vst3");
             expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
         }
@@ -138,13 +138,13 @@ struct CommandLineTests : public UnitTest
         {
             const auto commandLineString = "--validate MyPluginID";
             const auto args = createCommandLineArgs(commandLineString);
-            expectEquals (parseCommandLine (args).first, String ("MyPluginID"));
+            expectEquals (parseCommandLine (args).first,juce::String ("MyPluginID"));
         }
 
         beginTest ("Command line random");
         {
-            expectEquals (getRandomSeed (ArgumentList ({}, "--random-seed 0x7f2da1")), (int64) 8334753);
-            expectEquals (getRandomSeed (ArgumentList ({}, "--random-seed 0x692bc1f")), (int64) 110279711);
+            expectEquals (getRandomSeed (juce::ArgumentList ({}, "--random-seed 0x7f2da1")), (juce::int64) 8334753);
+            expectEquals (getRandomSeed (juce::ArgumentList ({}, "--random-seed 0x692bc1f")), (juce::int64) 110279711);
         }
 
         beginTest ("Implicit validate options");
@@ -156,7 +156,7 @@ struct CommandLineTests : public UnitTest
 
         beginTest ("Allows for other options after explicit --validate");
         {
-            const auto currentDir = File::getCurrentWorkingDirectory();
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
             const auto args = createCommandLineArgs ("--validate MyPlugin.vst3 --randomise");
             expectEquals (parseCommandLine (args).first, currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
             expect (parseCommandLine(args).second.randomiseTestOrder);

--- a/Source/CrashHandler.cpp
+++ b/Source/CrashHandler.cpp
@@ -12,6 +12,7 @@
 
  ==============================================================================*/
 
+#include "juce_core/juce_core.h"
 #include "CrashHandler.h"
 
 #if JUCE_MAC
@@ -20,16 +21,16 @@
 
 namespace
 {
-    String getExtraPlatformSpecificInfo()
+    juce::String getExtraPlatformSpecificInfo()
     {
        #if JUCE_MAC
-        StringArray imagesDone;
-        StringArray output;
+        juce::StringArray imagesDone;
+        juce::StringArray output;
 
-        for (auto& l : StringArray::fromLines (SystemStats::getStackBacktrace()))
+        for (auto& l : juce::StringArray::fromLines (juce::SystemStats::getStackBacktrace()))
         {
-            const String imageName = l.upToFirstOccurrenceOf ("0x", false, false).fromFirstOccurrenceOf (" ", false, false).trim();
-            const String addressString = l.fromFirstOccurrenceOf ("0x", true, false).upToFirstOccurrenceOf (" ", false, false).trim();
+            const juce::String imageName = l.upToFirstOccurrenceOf ("0x", false, false).fromFirstOccurrenceOf (" ", false, false).trim();
+            const juce::String addressString = l.fromFirstOccurrenceOf ("0x", true, false).upToFirstOccurrenceOf (" ", false, false).trim();
 
             if (imagesDone.contains (imageName))
                 continue;
@@ -40,7 +41,7 @@ namespace
             const size_t address = static_cast<size_t> (addressString.getHexValue64());
 
             if (dladdr (reinterpret_cast<void*> (address), &info) != 0)
-                output.add (String ("0x") + String::toHexString (static_cast<pointer_sized_int> (reinterpret_cast<size_t> (info.dli_fbase))) + " " + imageName);
+                output.add (juce::String ("0x") + juce::String::toHexString (static_cast<juce::pointer_sized_int> (reinterpret_cast<size_t> (info.dli_fbase))) + " " + imageName);
         }
 
         return "Binary Images:\n" + output.joinIntoString ("\n");
@@ -49,14 +50,14 @@ namespace
        #endif
     }
 
-    String getCrashLogContents()
+    juce::String getCrashLogContents()
     {
-        return "\n" + SystemStats::getStackBacktrace() + "\n" + getExtraPlatformSpecificInfo();
+        return "\n" + juce::SystemStats::getStackBacktrace() + "\n" + getExtraPlatformSpecificInfo();
     }
 
-    static File getCrashTraceFile()
+    static juce::File getCrashTraceFile()
     {
-        return File::getSpecialLocation (File::tempDirectory).getChildFile ("pluginval_crash.txt");
+        return juce::File::getSpecialLocation (juce::File::tempDirectory).getChildFile ("pluginval_crash.txt");
     }
 
     static void handleCrash (void*)
@@ -72,10 +73,10 @@ void initialiseCrashHandler()
 {
     // Delete the crash file, this will be created if possible
     getCrashTraceFile().deleteFile();
-    SystemStats::setApplicationCrashHandler (handleCrash);
+    juce::SystemStats::setApplicationCrashHandler (handleCrash);
 }
 
-String getCrashLog()
+juce::String getCrashLog()
 {
     const auto f = getCrashTraceFile();
 

--- a/Source/CrashHandler.h
+++ b/Source/CrashHandler.h
@@ -13,10 +13,10 @@
  ==============================================================================*/
 
 #pragma once
-#include <JuceHeader.h>
+
 
 /** Initialises crash handling in order to get stack traces when validation crashes occur. */
 void initialiseCrashHandler();
 
 /** Call this after a crash to get the most recent stack trace. */
-String getCrashLog();
+juce::String getCrashLog();

--- a/Source/Main.cpp
+++ b/Source/Main.cpp
@@ -12,32 +12,32 @@
 
  ==============================================================================*/
 
-#include <JuceHeader.h>
+#include <juce_gui_basics/juce_gui_basics.h>
 #include "MainComponent.h"
 #include "Validator.h"
 #include "CommandLine.h"
 
 //==============================================================================
-class PluginValidatorApplication  : public JUCEApplication,
-                                    private AsyncUpdater
+class PluginValidatorApplication  : public juce::JUCEApplication,
+                                   private juce::AsyncUpdater
 {
 public:
     //==============================================================================
     PluginValidatorApplication() = default;
 
-    PropertiesFile& getAppPreferences()
+    juce::PropertiesFile& getAppPreferences()
     {
         jassert (propertiesFile); // Calling this from the child process?
         return *propertiesFile;
     }
 
     //==============================================================================
-    const String getApplicationName() override       { return ProjectInfo::projectName; }
-    const String getApplicationVersion() override    { return ProjectInfo::versionString; }
+    const juce::String getApplicationName() override       { return "pluginval"; }
+    const juce::String getApplicationVersion() override    { return VERSION; }
     bool moreThanOneInstanceAllowed() override       { return true; }
 
     //==============================================================================
-    void initialise (const String& commandLine) override
+    void initialise (const juce::String& commandLine) override
     {
         if (shouldPerformCommandLine (commandLine))
         {
@@ -46,7 +46,7 @@ public:
         }
 
        #if JUCE_DEBUG
-        UnitTestRunner testRunner;
+        juce::UnitTestRunner testRunner;
         testRunner.runTestsInCategory ("pluginval");
        #endif
 
@@ -59,7 +59,7 @@ public:
     {
         mainWindow.reset();
         validator.reset();
-        Logger::setCurrentLogger (nullptr);
+        juce::Logger::setCurrentLogger (nullptr);
     }
 
     //==============================================================================
@@ -70,7 +70,7 @@ public:
         quit();
     }
 
-    void anotherInstanceStarted (const String&) override
+    void anotherInstanceStarted (const juce::String&) override
     {
         // When another instance of the app is launched while this one is running,
         // this method is invoked, and the commandLine parameter tells you what
@@ -82,12 +82,12 @@ public:
         This class implements the desktop window that contains an instance of
         our MainComponent class.
     */
-    class MainWindow    : public DocumentWindow
+    class MainWindow    : public juce::DocumentWindow
     {
     public:
-        MainWindow (Validator& v, String name)
+        MainWindow (Validator& v, juce::String name)
             : DocumentWindow (name,
-                              Desktop::getInstance().getDefaultLookAndFeel()
+                              juce::Desktop::getInstance().getDefaultLookAndFeel()
                                 .findColour (ResizableWindow::backgroundColourId),
                               DocumentWindow::allButtons)
         {
@@ -104,7 +104,7 @@ public:
             // This is called when the user tries to close this window. Here, we'll just
             // ask the app to quit when this happens, but you can change this to do
             // whatever you need.
-            JUCEApplication::getInstance()->systemRequestedQuit();
+            juce::JUCEApplication::getInstance()->systemRequestedQuit();
         }
 
         /* Note: Be careful if you override any DocumentWindow methods - the base
@@ -120,18 +120,18 @@ public:
 
 private:
     std::unique_ptr<Validator> validator;
-    std::unique_ptr<PropertiesFile> propertiesFile;
+    std::unique_ptr<juce::PropertiesFile> propertiesFile;
     std::unique_ptr<MainWindow> mainWindow;
-    std::unique_ptr<FileLogger> fileLogger;
+    std::unique_ptr<juce::FileLogger> fileLogger;
     std::unique_ptr<CommandLineValidator> commandLineValidator;
 
-    static PropertiesFile::Options getPropertiesFileOptions()
+    static juce::PropertiesFile::Options getPropertiesFileOptions()
     {
-        PropertiesFile::Options opts;
+        juce::PropertiesFile::Options opts;
         opts.millisecondsBeforeSaving = 2000;
-        opts.storageFormat = PropertiesFile::storeAsXML;
+        opts.storageFormat = juce::PropertiesFile::storeAsXML;
 
-        opts.applicationName = String (ProjectInfo::projectName);
+        opts.applicationName = juce::String ("pluginval");
         opts.filenameSuffix = ".xml";
         opts.folderName = opts.applicationName;
         opts.osxLibrarySubFolder = "Application Support";
@@ -155,16 +155,16 @@ private:
         return opts;
     }
 
-    static PropertiesFile* getPropertiesFile()
+    static juce::PropertiesFile* getPropertiesFile()
     {
         auto opts = getPropertiesFileOptions();
-        return new PropertiesFile (opts.getDefaultFile(), opts);
+        return new juce::PropertiesFile (opts.getDefaultFile(), opts);
     }
 
     void handleAsyncUpdate() override
     {
         commandLineValidator = std::make_unique<CommandLineValidator>();
-        performCommandLine (*commandLineValidator, JUCEApplication::getCommandLineParameters());
+        performCommandLine (*commandLineValidator, juce::JUCEApplication::getCommandLineParameters());
     }
 };
 
@@ -172,7 +172,7 @@ private:
 // This macro generates the main() routine that launches the app.
 START_JUCE_APPLICATION (PluginValidatorApplication)
 
-PropertiesFile& getAppPreferences()
+juce::PropertiesFile& getAppPreferences()
 {
     auto app = dynamic_cast<PluginValidatorApplication*> (PluginValidatorApplication::getInstance());
     return app->getAppPreferences();

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -341,7 +341,7 @@ MainComponent::MainComponent (Validator& v)
 
             juce::PopupMenu m;
             m.addItem (validateInProcess, TRANS("Validate in process"), true, getValidateInProcess());
-            m.addItem (showRandomSeed, TRANS("Set random seed (123)").replace ("123", "0x" + juce::String::toHexString (getRandomSeed()) + "/" +juce::String (getRandomSeed())));
+            m.addItem (showRandomSeed, TRANS("Set random seed (123)").replace ("123", "0x" + juce::String::toHexString (getRandomSeed()) + "/" + juce::String (getRandomSeed())));
             m.addItem (showTimeout, TRANS("Set timeout (123ms)").replace ("123",juce::String (getTimeoutMs())));
             m.addItem (verboseLogging, TRANS("Verbose logging"), true, getVerboseLogging());
             m.addItem (numRepeats, TRANS("Num repeats (123)").replace ("123",juce::String (getNumRepeats())));

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -20,20 +20,20 @@ namespace
 {
     void setStrictnessLevel (int newLevel)
     {
-        getAppPreferences().setValue ("strictnessLevel", jlimit (1, 10, newLevel));
+        getAppPreferences().setValue ("strictnessLevel", juce::jlimit (1, 10, newLevel));
     }
 
     int getStrictnessLevel()
     {
-        return jlimit (1, 10, getAppPreferences().getIntValue ("strictnessLevel", 5));
+        return juce::jlimit (1, 10, getAppPreferences().getIntValue ("strictnessLevel", 5));
     }
 
-    void setRandomSeed (int64 newSeed)
+    void setRandomSeed (juce::int64 newSeed)
     {
         getAppPreferences().setValue ("randomSeed", newSeed);
     }
 
-    int64 getRandomSeed()
+    juce::int64 getRandomSeed()
     {
         return getAppPreferences().getIntValue ("randomSeed", 0);
     }
@@ -48,12 +48,12 @@ namespace
         return getAppPreferences().getBoolValue ("validateInProcess", false);
     }
 
-    void setTimeoutMs (int64 newTimeout)
+    void setTimeoutMs (juce::int64 newTimeout)
     {
         getAppPreferences().setValue ("timeoutMs", newTimeout);
     }
 
-    int64 getTimeoutMs()
+    juce::int64 getTimeoutMs()
     {
         return getAppPreferences().getIntValue ("timeoutMs", 30000);
     }
@@ -76,7 +76,7 @@ namespace
 
     int getNumRepeats()
     {
-        return jmax (1, getAppPreferences().getIntValue ("numRepeats", 1));
+        return juce::jmax (1, getAppPreferences().getIntValue ("numRepeats", 1));
     }
 
     void setRandomiseTests (bool shouldRandomiseTests)
@@ -89,9 +89,9 @@ namespace
         return getAppPreferences().getBoolValue ("randomiseTests", false);
     }
 
-    File getOutputDir()
+    juce::File getOutputDir()
     {
-        return getAppPreferences().getValue ("outputDir", String());
+        return getAppPreferences().getValue ("outputDir", juce::String());
     }
 
     std::vector<double> getSampleRates() // from UI no setting of sampleRates yet
@@ -111,7 +111,7 @@ namespace
 
     juce::File getVST3Validator()
     {
-        return getAppPreferences().getValue ("vst3validator", String());
+        return getAppPreferences().getValue ("vst3validator", juce::String());
     }
 
     PluginTests::Options getTestOptions()
@@ -134,12 +134,12 @@ namespace
     //==============================================================================
     void showRandomSeedDialog()
     {
-        const String message = TRANS("Set the random seed to use for the tests, useful for replicating issues");
-        std::shared_ptr<AlertWindow> aw (LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Random Seed"), message,
-                                                                                                 TRANS("OK"), TRANS("Cancel"), String(),
-                                                                                                 AlertWindow::QuestionIcon, 2, nullptr));
-        aw->addTextEditor ("randomSeed", String (getRandomSeed()));
-        aw->enterModalState (true, ModalCallbackFunction::create ([aw] (int res)
+        const juce::String message = TRANS("Set the random seed to use for the tests, useful for replicating issues");
+        std::shared_ptr<juce::AlertWindow> aw (juce::LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Random Seed"), message,
+                                                                                                 TRANS("OK"), TRANS("Cancel"), juce::String(),
+                                                                                                 juce::AlertWindow::QuestionIcon, 2, nullptr));
+        aw->addTextEditor ("randomSeed",juce::String (getRandomSeed()));
+        aw->enterModalState (true, juce::ModalCallbackFunction::create ([aw] (int res)
                                                                   {
                                                                       if (res == 1)
                                                                       {
@@ -155,12 +155,12 @@ namespace
 
     void showTimeoutDialog()
     {
-        const String message = TRANS("Set the duration in milliseconds after which to kill the validation if there has been no output from it");
-        std::shared_ptr<AlertWindow> aw (LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Timeout (ms)"), message,
-                                                                                                 TRANS("OK"), TRANS("Cancel"), String(),
-                                                                                                 AlertWindow::QuestionIcon, 2, nullptr));
-        aw->addTextEditor ("timeoutMs", String (getTimeoutMs()));
-        aw->enterModalState (true, ModalCallbackFunction::create ([aw] (int res)
+        const juce::String message = TRANS("Set the duration in milliseconds after which to kill the validation if there has been no output from it");
+        std::shared_ptr<juce::AlertWindow> aw (juce::LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Timeout (ms)"), message,
+                                                                                                 TRANS("OK"), TRANS("Cancel"), juce::String(),
+                                                                                                 juce::AlertWindow::QuestionIcon, 2, nullptr));
+        aw->addTextEditor ("timeoutMs",juce::String (getTimeoutMs()));
+        aw->enterModalState (true, juce::ModalCallbackFunction::create ([aw] (int res)
                                                                   {
                                                                       if (res == 1)
                                                                           if (auto te = aw->getTextEditor ("timeoutMs"))
@@ -170,12 +170,12 @@ namespace
 
     void showNumRepeatsDialog()
     {
-        const String message = TRANS("Set the number of times the tests will be repeated");
-        std::shared_ptr<AlertWindow> aw (LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Number of Repeats"), message,
-                                                                                                 TRANS("OK"), TRANS("Cancel"), String(),
-                                                                                                 AlertWindow::QuestionIcon, 2, nullptr));
-        aw->addTextEditor ("repeats", String (getNumRepeats()));
-        aw->enterModalState (true, ModalCallbackFunction::create ([aw] (int res)
+        const juce::String message = TRANS("Set the number of times the tests will be repeated");
+        std::shared_ptr<juce::AlertWindow> aw (juce::LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Number of Repeats"), message,
+                                                                                                 TRANS("OK"), TRANS("Cancel"), juce::String(),
+                                                                                                 juce::AlertWindow::QuestionIcon, 2, nullptr));
+        aw->addTextEditor ("repeats",juce::String (getNumRepeats()));
+        aw->enterModalState (true, juce::ModalCallbackFunction::create ([aw] (int res)
                                                                   {
                                                                       if (res == 1)
                                                                           if (auto te = aw->getTextEditor ("repeats"))
@@ -185,7 +185,7 @@ namespace
 
     void showOutputDirDialog()
     {
-        String message = TRANS("Set a desintation directory to place log files");
+        juce::String message = TRANS("Set a desintation directory to place log files");
         auto dir = getOutputDir();
 
         if (dir.getFullPathName().isNotEmpty())
@@ -193,18 +193,18 @@ namespace
         else
             message << "\n\n" << "\"None set\"";
 
-        std::shared_ptr<AlertWindow> aw (LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Log File Directory"), message,
+        std::shared_ptr<juce::AlertWindow> aw (juce::LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set Log File Directory"), message,
                                                                                                  TRANS("Choose dir"), TRANS("Cancel"), TRANS("Don't save logs"),
-                                                                                                 AlertWindow::QuestionIcon, 3, nullptr));
-        aw->enterModalState (true, ModalCallbackFunction::create ([aw] (int res)
+                                                                                                 juce::AlertWindow::QuestionIcon, 3, nullptr));
+        aw->enterModalState (true, juce::ModalCallbackFunction::create ([aw] (int res)
                                                                   {
                                                                       if (res == 3)
-                                                                          getAppPreferences().setValue ("outputDir", String());
+                                                                          getAppPreferences().setValue ("outputDir", juce::String());
 
                                                                       if (res == 1)
                                                                       {
-                                                                          const auto defaultDir = File::getSpecialLocation (File::userDesktopDirectory).getChildFile ("pluginval logs").getFullPathName();
-                                                                          FileChooser fc (TRANS("Directory to save log files"), defaultDir);
+                                                                          const auto defaultDir = juce::File::getSpecialLocation (juce::File::userDesktopDirectory).getChildFile ("pluginval logs").getFullPathName();
+                                                                          juce::FileChooser fc (TRANS("Directory to save log files"), defaultDir);
 
                                                                           if (fc.browseForDirectory())
                                                                               getAppPreferences().setValue ("outputDir", fc.getResult().getFullPathName());
@@ -214,7 +214,7 @@ namespace
 
     void showVST3ValidatorDialog()
     {
-        String message = TRANS("Set the location of the VST3 validator app");
+        juce::String message = TRANS("Set the location of the VST3 validator app");
         auto app = getVST3Validator();
 
         if (app.getFullPathName().isNotEmpty())
@@ -222,17 +222,17 @@ namespace
         else
             message << "\n\n" << "\"None set\"";
 
-        std::shared_ptr<AlertWindow> aw (LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set VST3 validator"), message,
+        std::shared_ptr<juce::AlertWindow> aw (juce::LookAndFeel::getDefaultLookAndFeel().createAlertWindow (TRANS("Set VST3 validator"), message,
                                                                                                  TRANS("Choose"), TRANS("Cancel"), TRANS("Don't use VST3 validator"),
-                                                                                                 AlertWindow::QuestionIcon, 3, nullptr));
-        aw->enterModalState (true, ModalCallbackFunction::create ([aw] (int res)
+                                                                                                 juce::AlertWindow::QuestionIcon, 3, nullptr));
+        aw->enterModalState (true, juce::ModalCallbackFunction::create ([aw] (int res)
                                                                   {
                                                                       if (res == 3)
                                                                           setVST3Validator ({});
 
                                                                       if (res == 1)
                                                                       {
-                                                                          FileChooser fc (TRANS("Choose VST3 validator"), {});
+                                                                          juce::FileChooser fc (TRANS("Choose VST3 validator"), {});
 
                                                                           if (fc.browseForFileToOpen())
                                                                               setVST3Validator (fc.getResult().getFullPathName());
@@ -248,7 +248,7 @@ MainComponent::MainComponent (Validator& v)
 {
     formatManager.addDefaultFormats();
 
-    const auto tabCol = getLookAndFeel().findColour (ResizableWindow::backgroundColourId);
+    const auto tabCol = getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId);
     addAndMakeVisible (tabbedComponent);
     tabbedComponent.addTab ("Plugin List", tabCol, &pluginListComponent, false);
     tabbedComponent.addTab ("Console", tabCol, &console, false);
@@ -266,7 +266,7 @@ MainComponent::MainComponent (Validator& v)
     testSelectedButton.onClick = [this]
         {
             auto rows = pluginListComponent.getTableListBox().getSelectedRows();
-            Array<PluginDescription> plugins;
+            juce::Array<juce::PluginDescription> plugins;
 
             for (int i = 0; i < rows.size(); ++i)
                 plugins.add (knownPluginList.getTypes()[rows[i]]);
@@ -283,8 +283,8 @@ MainComponent::MainComponent (Validator& v)
 
     testFileButton.onClick = [this]
         {
-            FileChooser fc (TRANS("Browse for Plug-in File"),
-                            getAppPreferences().getValue ("lastPluginLocation", File::getSpecialLocation (File::userApplicationDataDirectory).getFullPathName()),
+            juce::FileChooser fc (TRANS("Browse for Plug-in File"),
+                            getAppPreferences().getValue ("lastPluginLocation", juce::File::getSpecialLocation (juce::File::userApplicationDataDirectory).getFullPathName()),
                             "*.vst;*.vst3;*.dll;*.component");
 
             if (fc.browseForFileToOpen())
@@ -304,8 +304,8 @@ MainComponent::MainComponent (Validator& v)
 
     saveButton.onClick = [this]
         {
-            FileChooser fc (TRANS("Save Log File"),
-                            getAppPreferences().getValue ("lastSaveLocation", File::getSpecialLocation (File::userDesktopDirectory).getFullPathName()),
+            juce::FileChooser fc (TRANS("Save Log File"),
+                            getAppPreferences().getValue ("lastSaveLocation", juce::File::getSpecialLocation (juce::File::userDesktopDirectory).getFullPathName()),
                             "*.txt");
 
             if (fc.browseForFileToSave (true))
@@ -318,7 +318,7 @@ MainComponent::MainComponent (Validator& v)
                 }
                 else
                 {
-                    AlertWindow::showMessageBoxAsync (AlertWindow::WarningIcon, TRANS("Unable to Save"),
+                    juce::AlertWindow::showMessageBoxAsync (juce::AlertWindow::WarningIcon, TRANS("Unable to Save"),
                                                       TRANS("Unable to save to the file at location: XYYX").replace ("XYYX", f.getFullPathName()));
                 }
             }
@@ -339,18 +339,18 @@ MainComponent::MainComponent (Validator& v)
                 showSettingsDir
             };
 
-            PopupMenu m;
+            juce::PopupMenu m;
             m.addItem (validateInProcess, TRANS("Validate in process"), true, getValidateInProcess());
-            m.addItem (showRandomSeed, TRANS("Set random seed (123)").replace ("123", "0x" + String::toHexString (getRandomSeed()) + "/" + String (getRandomSeed())));
-            m.addItem (showTimeout, TRANS("Set timeout (123ms)").replace ("123", String (getTimeoutMs())));
+            m.addItem (showRandomSeed, TRANS("Set random seed (123)").replace ("123", "0x" + juce::String::toHexString (getRandomSeed()) + "/" +juce::String (getRandomSeed())));
+            m.addItem (showTimeout, TRANS("Set timeout (123ms)").replace ("123",juce::String (getTimeoutMs())));
             m.addItem (verboseLogging, TRANS("Verbose logging"), true, getVerboseLogging());
-            m.addItem (numRepeats, TRANS("Num repeats (123)").replace ("123", String (getNumRepeats())));
+            m.addItem (numRepeats, TRANS("Num repeats (123)").replace ("123",juce::String (getNumRepeats())));
             m.addItem (randomise, TRANS("Randomise tests"), true, getRandomiseTests());
             m.addItem (chooseOutputDir, TRANS("Choose a location for log files"));
             m.addItem (showVST3Validator, TRANS("Set the location of the VST3 validator"));
             m.addSeparator();
             m.addItem (showSettingsDir, TRANS("Show settings folder"));
-            m.showMenuAsync (PopupMenu::Options().withTargetComponent (&optionsButton),
+            m.showMenuAsync (juce::PopupMenu::Options().withTargetComponent (&optionsButton),
                              [sp] (int res) mutable
                              {
                                  if (res == validateInProcess)
@@ -393,17 +393,17 @@ MainComponent::MainComponent (Validator& v)
                              });
         };
 
-    strictnessSlider.setTextBoxStyle (Slider::TextBoxLeft, false, 35, 24);
-    strictnessSlider.setSliderStyle (Slider::IncDecButtons);
+    strictnessSlider.setTextBoxStyle (juce::Slider::TextBoxLeft, false, 35, 24);
+    strictnessSlider.setSliderStyle (juce::Slider::IncDecButtons);
     strictnessSlider.setRange ({ 1.0, 10.0 }, 1.0);
     strictnessSlider.setNumDecimalPlacesToDisplay (0);
     strictnessSlider.setValue (getStrictnessLevel());
     strictnessSlider.onValueChange = [this]
         {
-            setStrictnessLevel (roundToInt (strictnessSlider.getValue()));
+            setStrictnessLevel (juce::roundToInt (strictnessSlider.getValue()));
         };
 
-    if (auto xml = std::unique_ptr<XmlElement> (getAppPreferences().getXmlValue ("scannedPlugins")))
+    if (auto xml = std::unique_ptr<juce::XmlElement> (getAppPreferences().getXmlValue ("scannedPlugins")))
         knownPluginList.recreateFromXml (*xml);
 
     knownPluginList.addChangeListener (this);
@@ -417,9 +417,9 @@ MainComponent::~MainComponent()
 }
 
 //==============================================================================
-void MainComponent::paint (Graphics& g)
+void MainComponent::paint (juce::Graphics& g)
 {
-    g.fillAll (getLookAndFeel().findColour (ResizableWindow::backgroundColourId));
+    g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 }
 
 void MainComponent::resized()
@@ -445,11 +445,11 @@ void MainComponent::resized()
 //==============================================================================
 void MainComponent::savePluginList()
 {
-    if (auto xml = std::unique_ptr<XmlElement> (knownPluginList.createXml()))
+    if (auto xml = std::unique_ptr<juce::XmlElement> (knownPluginList.createXml()))
         getAppPreferences().setValue ("scannedPlugins", xml.get());
 }
 
-void MainComponent::changeListenerCallback (ChangeBroadcaster*)
+void MainComponent::changeListenerCallback (juce::ChangeBroadcaster*)
 {
     savePluginList();
 }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -201,7 +201,7 @@ private:
         if (exitCode == 0)
             logMessage ("ALL TESTS PASSED\n");
         else
-            logMessage ("*** FAILED WITH EXIT CODE: " +juce::String (exitCode) + "\n");
+            logMessage ("*** FAILED WITH EXIT CODE: " + juce::String (exitCode) + "\n");
 
         currentID = juce::String();
     }

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -14,15 +14,15 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_gui_extra/juce_gui_extra.h"
 #include "Validator.h"
 #include "CrashHandler.h"
 
-PropertiesFile& getAppPreferences();
+juce::PropertiesFile& getAppPreferences();
 
 //==============================================================================
-struct ConnectionStatus : public Component,
-                          private ChangeListener,
+struct ConnectionStatus : public juce::Component,
+                          private juce::ChangeListener,
                           private Validator::Listener
 {
     ConnectionStatus (Validator& v)
@@ -38,24 +38,24 @@ struct ConnectionStatus : public Component,
         validator.removeChangeListener (this);
     }
 
-    void paint (Graphics& g) override
+    void paint (juce::Graphics& g) override
     {
         auto r = getLocalBounds().toFloat();
 
         g.setColour ([this] {
             switch (status)
             {
-                case Status::disconnected:  return Colours::darkred;
-                case Status::validating:    return Colours::orange;
+                case Status::disconnected:  return juce::Colours::darkred;
+                case Status::validating:    return juce::Colours::orange;
                 case Status::connected:
-                case Status::complete:      return Colours::lightgreen;
+                case Status::complete:      return juce::Colours::lightgreen;
             }
 
-            return Colours::darkred;
+            return juce::Colours::darkred;
         }());
         g.fillEllipse (r);
 
-        g.setColour (Colours::darkgrey);
+        g.setColour (juce::Colours::darkgrey);
         g.drawEllipse (r.reduced (1.0f), 2.0f);
     }
 
@@ -74,24 +74,24 @@ private:
     void setStatus (Status newStatus)
     {
         status = newStatus;
-        MessageManager::callAsync ([sp = SafePointer<Component> (this)] () mutable { if (sp != nullptr) sp->repaint(); });
+        juce::MessageManager::callAsync ([sp = SafePointer<Component> (this)] () mutable { if (sp != nullptr) sp->repaint(); });
     }
 
-    void changeListenerCallback (ChangeBroadcaster*) override
+    void changeListenerCallback (juce::ChangeBroadcaster*) override
     {
         setStatus (validator.isConnected() ? Status::connected : Status::disconnected);
     }
 
-    void validationStarted (const String&) override
+    void validationStarted (const juce::String&) override
     {
         setStatus (Status::validating);
     }
 
-    void logMessage (const String&) override
+    void logMessage (const juce::String&) override
     {
     }
 
-    void itemComplete (const String&, uint32_t) override
+    void itemComplete (const juce::String&, uint32_t) override
     {
     }
 
@@ -102,9 +102,9 @@ private:
 };
 
 //==============================================================================
-struct ConsoleComponent : public Component,
-                          private ChangeListener,
-                          private AsyncUpdater,
+struct ConsoleComponent : public juce::Component,
+                          private juce::ChangeListener,
+                          private juce::AsyncUpdater,
                           private Validator::Listener
 {
     ConsoleComponent (Validator& v)
@@ -125,14 +125,14 @@ struct ConsoleComponent : public Component,
         validator.removeListener (this);
     }
 
-    String getLog() const
+    juce::String getLog() const
     {
         return codeDocument.getAllContent();
     }
 
     void clearLog()
     {
-        codeDocument.replaceAllContent (String());
+        codeDocument.replaceAllContent (juce::String());
     }
 
     void resized() override
@@ -144,19 +144,19 @@ struct ConsoleComponent : public Component,
 private:
     Validator& validator;
 
-    CodeDocument codeDocument;
-    CodeEditorComponent editor { codeDocument, nullptr };
-    String currentID;
+    juce::CodeDocument codeDocument;
+    juce::CodeEditorComponent editor { codeDocument, nullptr };
+    juce::String currentID;
 
-    CriticalSection logMessagesLock;
-    StringArray pendingLogMessages;
+    juce::CriticalSection logMessagesLock;
+    juce::StringArray pendingLogMessages;
 
     void handleAsyncUpdate() override
     {
-        StringArray logMessages;
+        juce::StringArray logMessages;
 
         {
-            const ScopedLock sl (logMessagesLock);
+            const juce::ScopedLock sl (logMessagesLock);
             pendingLogMessages.swapWith (logMessages);
         }
 
@@ -167,26 +167,26 @@ private:
         }
     }
 
-    void changeListenerCallback (ChangeBroadcaster*) override
+    void changeListenerCallback (juce::ChangeBroadcaster*) override
     {
         if (! validator.isConnected() && currentID.isNotEmpty())
         {
             logMessage ("\n*** FAILED: VALIDATION CRASHED\n");
             logMessage (getCrashLog());
-            currentID = String();
+            currentID = juce::String();
         }
     }
 
-    void validationStarted (const String& id) override
+    void validationStarted (const juce::String& id) override
     {
         currentID = id;
         logMessage ("Started validating: " + id + "\n");
     }
 
-    void logMessage (const String& m) override
+    void logMessage (const juce::String& m) override
     {
         {
-            const ScopedLock sl (logMessagesLock);
+            const juce::ScopedLock sl (logMessagesLock);
             pendingLogMessages.add (m);
             triggerAsyncUpdate();
         }
@@ -194,16 +194,16 @@ private:
         std::cout << m;
     }
 
-    void itemComplete (const String& id, uint32_t exitCode) override
+    void itemComplete (const juce::String& id, uint32_t exitCode) override
     {
         logMessage ("\nFinished validating: " + id + "\n");
 
         if (exitCode == 0)
             logMessage ("ALL TESTS PASSED\n");
         else
-            logMessage ("*** FAILED WITH EXIT CODE: " + String (exitCode) + "\n");
+            logMessage ("*** FAILED WITH EXIT CODE: " +juce::String (exitCode) + "\n");
 
-        currentID = String();
+        currentID = juce::String();
     }
 
     void allItemsComplete() override
@@ -217,8 +217,8 @@ private:
     This component lives inside our window, and this is where you should put all
     your controls and content.
 */
-class MainComponent   : public Component,
-                        private ChangeListener
+class MainComponent   : public juce::Component,
+                        private juce::ChangeListener
 {
 public:
     //==============================================================================
@@ -226,30 +226,30 @@ public:
     ~MainComponent() override;
 
     //==============================================================================
-    void paint (Graphics&) override;
+    void paint (juce::Graphics&) override;
     void resized() override;
 
 private:
     //==============================================================================
     Validator& validator;
 
-    AudioPluginFormatManager formatManager;
-    KnownPluginList knownPluginList;
+    juce::AudioPluginFormatManager formatManager;
+    juce::KnownPluginList knownPluginList;
 
-    TabbedComponent tabbedComponent { TabbedButtonBar::TabsAtTop };
-    PluginListComponent pluginListComponent { formatManager, knownPluginList,
+    juce::TabbedComponent tabbedComponent { juce::TabbedButtonBar::TabsAtTop };
+    juce::PluginListComponent pluginListComponent { formatManager, knownPluginList,
                                               getAppPreferences().getFile().getSiblingFile ("PluginsListDeadMansPedal"),
                                               &getAppPreferences() };
     ConsoleComponent console { validator };
-    TextButton testSelectedButton { "Test Selected" }, testAllButton { "Test All" }, testFileButton { "Test File" },
+    juce::TextButton testSelectedButton { "Test Selected" }, testAllButton { "Test All" }, testFileButton { "Test File" },
                clearButton { "Clear Log" }, saveButton { "Save Log" }, optionsButton { "Options" };
-    Slider strictnessSlider;
-    Label strictnessLabel { {}, "Strictness Level" };
+    juce::Slider strictnessSlider;
+    juce::Label strictnessLabel { {}, "Strictness Level" };
     ConnectionStatus connectionStatus { validator };
 
     void savePluginList();
 
-    void changeListenerCallback (ChangeBroadcaster*) override;
+    void changeListenerCallback (juce::ChangeBroadcaster*) override;
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainComponent)
 };

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -19,25 +19,25 @@
 namespace
 {
     /** Deletes a plugin asyncronously on the message thread */
-    void deletePluginAsync (std::unique_ptr<AudioPluginInstance> pluginInstance)
+    void deletePluginAsync (std::unique_ptr<juce::AudioPluginInstance> pluginInstance)
     {
-        WaitableEvent completionEvent;
+        juce::WaitableEvent completionEvent;
 
-        struct AsyncDeleter : public CallbackMessage
+        struct AsyncDeleter : public juce::CallbackMessage
         {
-            AsyncDeleter (std::unique_ptr<AudioPluginInstance> api, WaitableEvent& we)
+            AsyncDeleter (std::unique_ptr<juce::AudioPluginInstance> api, juce::WaitableEvent& we)
                 : instance (std::move (api)), event (we)
             {}
 
             void messageCallback() override
             {
                 instance.reset();
-                Thread::sleep (150); // Pause a few ms to let the plugin clean up after itself
+                juce::Thread::sleep (150); // Pause a few ms to let the plugin clean up after itself
                 event.signal();
             }
 
-            std::unique_ptr<AudioPluginInstance> instance;
-            WaitableEvent& event;
+            std::unique_ptr<juce::AudioPluginInstance> instance;
+            juce::WaitableEvent& event;
         };
 
         (new AsyncDeleter (std::move (pluginInstance), completionEvent))->post();
@@ -45,23 +45,23 @@ namespace
     }
 }
 
-PluginTests::PluginTests (const String& fileOrIdentifier, Options opts)
-    : UnitTest ("pluginval"),
+PluginTests::PluginTests (const juce::String& fileOrIdentifier, Options opts)
+    : juce::UnitTest ("pluginval"),
       fileOrID (fileOrIdentifier),
       options (opts)
 {
     jassert (fileOrIdentifier.isNotEmpty());
-    jassert (isPositiveAndNotGreaterThan (options.strictnessLevel, 10));
+    jassert (juce::isPositiveAndNotGreaterThan (options.strictnessLevel, 10));
     formatManager.addDefaultFormats();
 }
 
-PluginTests::PluginTests (const PluginDescription& desc, Options opts)
-    : PluginTests (String(), opts)
+PluginTests::PluginTests (const juce::PluginDescription& desc, Options opts)
+    : PluginTests (juce::String(), opts)
 {
-    typesFound.add (new PluginDescription (desc));
+    typesFound.add (new juce::PluginDescription (desc));
 }
 
-String PluginTests::getFileOrID() const
+juce::String PluginTests::getFileOrID() const
 {
     if (fileOrID.isNotEmpty())
         return fileOrID;
@@ -72,15 +72,15 @@ String PluginTests::getFileOrID() const
     return {};
 }
 
-void PluginTests::logVerboseMessage (const String& message)
+void PluginTests::logVerboseMessage (const juce::String& message)
 {
     // We still need to send an empty message or the test may timeout
-    logMessage (options.verbose ? message : String());
+    logMessage (options.verbose ? message : juce::String());
 }
 
 void PluginTests::resetTimeout()
 {
-    logMessage (String());
+    logMessage (juce::String());
 }
 
 void PluginTests::runTest()
@@ -89,22 +89,22 @@ void PluginTests::runTest()
     jassert (! juce::MessageManager::existsAndIsCurrentThread());
 
     logMessage ("Validation started");
-    logVerboseMessage ("\t" + Time::getCurrentTime().toString (true, true) + "\n");
-    logMessage ("Strictness level: " + String (options.strictnessLevel));
+    logVerboseMessage ("\t" + juce::Time::getCurrentTime().toString (true, true) + "\n");
+    logMessage ("Strictness level: " +juce::String (options.strictnessLevel));
 
     if (fileOrID.isNotEmpty())
     {
         beginTest ("Scan for plugins located in: " + fileOrID);
 
-        WaitableEvent completionEvent;
-        MessageManager::callAsync ([&, this]() mutable
+        juce::WaitableEvent completionEvent;
+        juce::MessageManager::callAsync ([&, this]() mutable
                                    {
-                                       knownPluginList.scanAndAddDragAndDroppedFiles (formatManager, StringArray (fileOrID), typesFound);
+                                       knownPluginList.scanAndAddDragAndDroppedFiles (formatManager, juce::StringArray (fileOrID), typesFound);
                                        completionEvent.signal();
                                    });
         completionEvent.wait();
 
-        logMessage ("Num plugins found: " + String (typesFound.size()));
+        logMessage ("Num plugins found: " +juce::String (typesFound.size()));
         expect (! typesFound.isEmpty(),
                 "No types found. This usually means the plugin binary is missing or damaged, "
                 "an incompatible format or that it is an AU that isn't found by macOS so can't be created.");
@@ -114,17 +114,17 @@ void PluginTests::runTest()
         testType (*pd);
 }
 
-std::unique_ptr<AudioPluginInstance> PluginTests::testOpenPlugin (const PluginDescription& pd)
+std::unique_ptr<juce::AudioPluginInstance> PluginTests::testOpenPlugin (const juce::PluginDescription& pd)
 {
-    String errorMessage;
-    auto instance = std::unique_ptr<AudioPluginInstance> (formatManager.createPluginInstance (pd, 44100.0, 512, errorMessage));
-    expectEquals (errorMessage, String());
-    expect (instance != nullptr, "Unable to create AudioPluginInstance");
+    juce::String errorMessage;
+    auto instance = std::unique_ptr<juce::AudioPluginInstance> (formatManager.createPluginInstance (pd, 44100.0, 512, errorMessage));
+    expectEquals (errorMessage, juce::String());
+    expect (instance != nullptr, "Unable to create juce::AudioPluginInstance");
 
     return instance;
 }
 
-void PluginTests::testType (const PluginDescription& pd)
+void PluginTests::testType (const juce::PluginDescription& pd)
 {
     StopwatchTimer totalTimer;
     logMessage ("\nTesting plugin: " + pd.createIdentifierString());
@@ -144,7 +144,7 @@ void PluginTests::testType (const PluginDescription& pd)
         if (auto instance = testOpenPlugin (pd))
         {
             logVerboseMessage ("\nTime taken to open plugin (warm): " + sw.getDescription());
-            logMessage (String ("Running tests 123 times").replace ("123", String (options.numRepeats)));
+            logMessage (juce::String ("Running tests 123 times").replace ("123",juce::String (options.numRepeats)));
 
             // This sleep is here to allow time for plugin async initialisation as in most cases
             // plugins will be added to tracks and then be played a little time later. This sleep
@@ -153,15 +153,15 @@ void PluginTests::testType (const PluginDescription& pd)
             // The exception to this is if the plugin is being rendered there's likely to be no gap
             // between construction, initialisation and processing. For this case, plugins should
             // check AudioProcessor::isNonRealtime and force initialisation if rendering.
-            Thread::sleep (150);
+            juce::Thread::sleep (150);
             auto r = getRandom();
 
             for (int testRun = 0; testRun < options.numRepeats; ++testRun)
             {
                 if (options.numRepeats > 1)
-                    logMessage ("\nTest run: " + String (testRun + 1));
+                    logMessage ("\nTest run: " +juce::String (testRun + 1));
 
-                Array<PluginTest*> testsToRun = PluginTest::getAllTests();
+                juce::Array<PluginTest*> testsToRun = PluginTest::getAllTests();
 
                 if (options.randomiseTestOrder)
                 {
@@ -186,8 +186,8 @@ void PluginTests::testType (const PluginDescription& pd)
 
                     if (t->needsToRunOnMessageThread())
                     {
-                        WaitableEvent completionEvent;
-                        MessageManager::callAsync ([&, this]() mutable
+                        juce::WaitableEvent completionEvent;
+                        juce::MessageManager::callAsync ([&, this]() mutable
                                                    {
                                                        t->runTest (*this, *instance);
                                                        completionEvent.signal();

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -90,7 +90,7 @@ void PluginTests::runTest()
 
     logMessage ("Validation started");
     logVerboseMessage ("\t" + juce::Time::getCurrentTime().toString (true, true) + "\n");
-    logMessage ("Strictness level: " +juce::String (options.strictnessLevel));
+    logMessage ("Strictness level: " + juce::String (options.strictnessLevel));
 
     if (fileOrID.isNotEmpty())
     {
@@ -104,7 +104,7 @@ void PluginTests::runTest()
                                    });
         completionEvent.wait();
 
-        logMessage ("Num plugins found: " +juce::String (typesFound.size()));
+        logMessage ("Num plugins found: " + juce::String (typesFound.size()));
         expect (! typesFound.isEmpty(),
                 "No types found. This usually means the plugin binary is missing or damaged, "
                 "an incompatible format or that it is an AU that isn't found by macOS so can't be created.");
@@ -159,7 +159,7 @@ void PluginTests::testType (const juce::PluginDescription& pd)
             for (int testRun = 0; testRun < options.numRepeats; ++testRun)
             {
                 if (options.numRepeats > 1)
-                    logMessage ("\nTest run: " +juce::String (testRun + 1));
+                    logMessage ("\nTest run: " + juce::String (testRun + 1));
 
                 juce::Array<PluginTest*> testsToRun = PluginTest::getAllTests();
 

--- a/Source/PluginTests.h
+++ b/Source/PluginTests.h
@@ -14,51 +14,51 @@
 
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_audio_processors/juce_audio_processors.h"
 
 //==============================================================================
 /**
-    The UnitTest which will create the plugins and run each of the registered tests on them.
+    The juce::UnitTest which will create the plugins and run each of the registered tests on them.
 */
-struct PluginTests : public UnitTest
+struct PluginTests : public juce::UnitTest
 {
     //==============================================================================
     /** A set of options to use when running tests. */
     struct Options
     {
         int strictnessLevel = 5;            /**< Max test level to run. */
-        int64 randomSeed = 0;               /**< The seed to use for the tests, 0 signifies a randomly generated seed. */
-        int64 timeoutMs = 30000;            /**< Timeout after which to kill the test. */
+        juce::int64 randomSeed = 0;               /**< The seed to use for the tests, 0 signifies a randomly generated seed. */
+        juce::int64 timeoutMs = 30000;            /**< Timeout after which to kill the test. */
         bool verbose = false;               /**< Whether or not to log additional information. */
         int numRepeats = 1;                 /**< The number of times to repeat the tests. */
         bool randomiseTestOrder = false;    /**< Whether to randomise the order of the tests in each repeat. */
         bool withGUI = true;                /**< Whether or not avoid tests that instantiate a gui. */
-        File dataFile;                      /**< File which tests can use to run user provided data. */
-        File outputDir;                     /**< Directory in which to write the log files for each test run. */
-        StringArray disabledTests;          /**< List of disabled tests. */
+        juce::File dataFile;                      /**< juce::File which tests can use to run user provided data. */
+        juce::File outputDir;                     /**< Directory in which to write the log files for each test run. */
+        juce::StringArray disabledTests;          /**< List of disabled tests. */
         std::vector<double> sampleRates;    /**< List of sample rates. */
         std::vector<int> blockSizes;        /**< List of block sizes. */
-        File vst3Validator;                 /**< File to use as the VST3 validator app. */
+        juce::File vst3Validator;                 /**< juce::File to use as the VST3 validator app. */
     };
 
     /** Creates a set of tests for a fileOrIdentifier. */
-    PluginTests (const String& fileOrIdentifier, Options);
+    PluginTests (const juce::String& fileOrIdentifier, Options);
 
     /** Creates a set of tests for a PluginDescription. */
-    PluginTests (const PluginDescription&, Options);
+    PluginTests (const juce::PluginDescription&, Options);
 
     /** Returns the file or ID used to create this. */
-    String getFileOrID() const;
+    juce::String getFileOrID() const;
 
     /** Call this after you've run the test to return information about the PluginDescriptions found. */
-    const OwnedArray<PluginDescription>& getDescriptions() const    { return typesFound; }
+    const juce::OwnedArray<juce::PluginDescription>& getDescriptions() const    { return typesFound; }
 
     //==============================================================================
     /** Returns the set of options currently being used to run the tests. */
     Options getOptions() const                       { return options; }
 
     /** Logs a verbose message which may be ommited from logs if the verbose option is not specified. */
-    void logVerboseMessage (const String& message);
+    void logVerboseMessage (const juce::String& message);
 
     /** Resets the timeout. Call this from long tests that don't log messages. */
     void resetTimeout();
@@ -68,15 +68,15 @@ struct PluginTests : public UnitTest
     void runTest() override;
 
 private:
-    const String fileOrID;
+    const juce::String fileOrID;
     const Options options;
-    AudioPluginFormatManager formatManager;
-    KnownPluginList knownPluginList;
+    juce::AudioPluginFormatManager formatManager;
+    juce::KnownPluginList knownPluginList;
 
-    OwnedArray<PluginDescription> typesFound;
+    juce::OwnedArray<juce::PluginDescription> typesFound;
 
-    std::unique_ptr<AudioPluginInstance> testOpenPlugin (const PluginDescription&);
-    void testType (const PluginDescription&);
+    std::unique_ptr<juce::AudioPluginInstance> testOpenPlugin (const juce::PluginDescription&);
+    void testType (const juce::PluginDescription&);
 };
 
 //==============================================================================
@@ -122,14 +122,14 @@ struct PluginTest
         @param testName                 The name of the test
         @param testStrictnessLevel      The conformance level of the test
     */
-    PluginTest (const String& testName,
+    PluginTest (const juce::String& testName,
                 int testStrictnessLevel,
                 Requirements testRequirements = { Requirements::Thread::backgroundThread, Requirements::GUI::noGUI })
         : name (testName),
           strictnessLevel (testStrictnessLevel),
           requirements (testRequirements)
     {
-        jassert (isPositiveAndNotGreaterThan (strictnessLevel, 10));
+        jassert (juce::isPositiveAndNotGreaterThan (strictnessLevel, 10));
         getAllTests().add (this);
     }
 
@@ -140,9 +140,9 @@ struct PluginTest
     }
 
     /** Returns a static list of all the tests. */
-    static Array<PluginTest*>& getAllTests()
+    static juce::Array<PluginTest*>& getAllTests()
     {
-        static Array<PluginTest*> tests;
+        static juce::Array<PluginTest*> tests;
         return tests;
     }
 
@@ -161,14 +161,14 @@ struct PluginTest
 
     //==============================================================================
     /** Override to perform any tests.
-        Note that because PluginTest doesn't inherit from UnitTest (due to being passed
-        in the AudioPluginInstance), you can use the UnitTest parameter to log messages or
+        Note that because PluginTest doesn't inherit from juce::UnitTest (due to being passed
+        in the juce::AudioPluginInstance), you can use the juce::UnitTest parameter to log messages or
         call expect etc.
     */
-    virtual void runTest (PluginTests& runningTest, AudioPluginInstance&) = 0;
+    virtual void runTest (PluginTests& runningTest, juce::AudioPluginInstance&) = 0;
 
     //==============================================================================
-    const String name;
+    const juce::String name;
     const int strictnessLevel;
     const Requirements requirements;
 };

--- a/Source/TestUtilities.cpp
+++ b/Source/TestUtilities.cpp
@@ -44,7 +44,7 @@ inline void violationError (const std::string& text)
     }
 }
 
-inline bool thowIfRequiredAndReturnShouldLog()
+inline bool throwIfRequiredAndReturnShouldLog()
 {
     switch (AllocatorInterceptor::getViolationBehaviour())
     {
@@ -70,7 +70,7 @@ inline bool thowIfRequiredAndReturnShouldLog()
 ATTRIBUTE_USED void* operator new (std::size_t sz)
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal allocation of " << sz << " bytes\n";
 
     return std::malloc (sz);
@@ -79,7 +79,7 @@ ATTRIBUTE_USED void* operator new (std::size_t sz)
 ATTRIBUTE_USED void* operator new[] (std::size_t sz)
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal array allocation of " << sz << " bytes\n";
 
     return std::malloc (sz);
@@ -88,7 +88,7 @@ ATTRIBUTE_USED void* operator new[] (std::size_t sz)
 ATTRIBUTE_USED void operator delete (void* ptr) noexcept
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal deletion\n";
 
     std::free (ptr);
@@ -97,7 +97,7 @@ ATTRIBUTE_USED void operator delete (void* ptr) noexcept
 ATTRIBUTE_USED void operator delete[] (void* ptr) noexcept
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal array deletion\n";
 
     std::free (ptr);
@@ -107,7 +107,7 @@ ATTRIBUTE_USED void operator delete[] (void* ptr) noexcept
 void operator delete (void* ptr, size_t) noexcept
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal deletion\n";
 
     std::free (ptr);
@@ -116,7 +116,7 @@ void operator delete (void* ptr, size_t) noexcept
 void operator delete[] (void* ptr, size_t) noexcept
 {
     if (! logAllocationViolationIfNotAllowed())
-        if (thowIfRequiredAndReturnShouldLog())
+        if (throwIfRequiredAndReturnShouldLog())
             std::cerr << "!!! WARNING: Illegal array deletion\n";
 
     std::free (ptr);
@@ -147,11 +147,11 @@ ScopedAllocationDisabler::ScopedAllocationDisabler()    { getAllocatorIntercepto
 ScopedAllocationDisabler::~ScopedAllocationDisabler()   { getAllocatorInterceptor().enableAllocations(); }
 
 //==============================================================================
-struct AllocatorInterceptorTests    : public UnitTest,
-                                      private AsyncUpdater
+struct AllocatorInterceptorTests    : public juce::UnitTest,
+                                      private juce::AsyncUpdater
 {
     AllocatorInterceptorTests()
-        : UnitTest ("AllocatorInterceptorTests", "pluginval")
+        : juce::UnitTest ("AllocatorInterceptorTests", "pluginval")
     {
     }
 
@@ -242,7 +242,7 @@ struct AllocatorInterceptorTests    : public UnitTest,
 private:
     void performAllocations()
     {
-        String s ("Hello world");
+        juce::String s ("Hello world");
         std::vector<float> floats (42);
         triggerAsyncUpdate();
 

--- a/Source/Validator.h
+++ b/Source/Validator.h
@@ -11,10 +11,9 @@
    DISCLAIMED.
 
  ==============================================================================*/
-
 #pragma once
 
-#include <JuceHeader.h>
+#include "juce_audio_processors/juce_audio_processors.h"
 #include "PluginTests.h"
 
 class ChildProcessValidator;
@@ -47,13 +46,13 @@ public:
     ValidationPass (const juce::String& fileOrIdToValidate, PluginTests::Options, ValidationType,
                     std::function<void (juce::String)> validationStarted,
                     std::function<void (juce::String, uint32_t /*exitCode*/)> validationEnded,
-                    std::function<void(const String&)> outputGenerated);
+                    std::function<void(const juce::String&)> outputGenerated);
 
     /** Destructor. */
     ~ValidationPass();
 
     /** Returns true when the validation pass has ended. */
-    bool hasFinished() const;
+    [[nodiscard]] bool hasFinished() const;
 
 private:
     //==============================================================================
@@ -68,8 +67,8 @@ private:
     Manages validation calls via a separate process and provides a listener
     interface to find out the results of the validation.
 */
-class Validator : public ChangeBroadcaster,
-                  private AsyncUpdater
+class Validator : public juce::ChangeBroadcaster,
+                  private juce::AsyncUpdater
 {
 public:
     //==============================================================================
@@ -83,10 +82,10 @@ public:
     bool isConnected() const;
 
     /** Validates an array of fileOrIDs. */
-    bool validate (const StringArray& fileOrIDsToValidate, PluginTests::Options);
+    bool validate (const juce::StringArray& fileOrIDsToValidate, PluginTests::Options);
 
     /** Validates an array of PluginDescriptions. */
-    bool validate (const Array<PluginDescription>& pluginsToValidate, PluginTests::Options);
+    bool validate (const juce::Array<juce::PluginDescription>& pluginsToValidate, PluginTests::Options);
 
     /** Call this to make validation happen in the same process.
         This can be useful for debugging but should not generally be used as a crashing
@@ -99,9 +98,9 @@ public:
     {
         virtual ~Listener() = default;
 
-        virtual void validationStarted (const String& idString) = 0;
-        virtual void logMessage (const String&) = 0;
-        virtual void itemComplete (const String& idString, uint32_t exitCode) = 0;
+        virtual void validationStarted (const juce::String& idString) = 0;
+        virtual void logMessage (const juce::String&) = 0;
+        virtual void itemComplete (const juce::String& idString, uint32_t exitCode) = 0;
         virtual void allItemsComplete() = 0;
     };
 
@@ -111,10 +110,10 @@ public:
 private:
     //==============================================================================
     std::unique_ptr<MultiValidator> multiValidator;
-    ListenerList<Listener> listeners;
+    juce::ListenerList<Listener> listeners;
     bool launchInProcess = false;
 
-    void logMessage (const String&);
+    void logMessage (const juce::String&);
 
     void handleAsyncUpdate() override;
 };

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -29,9 +29,9 @@ struct PluginInfoTest   : public PluginTest
     {
         ut.logMessage ("\nPlugin name: " + instance.getName());
         ut.logMessage ("Alternative names: " + instance.getAlternateDisplayNames().joinIntoString ("|"));
-        ut.logMessage ("SupportsDoublePrecision: " +juce::String (instance.supportsDoublePrecisionProcessing() ? "yes" : "no"));
-        ut.logMessage ("Reported latency: " +juce::String (instance.getLatencySamples()));
-        ut.logMessage ("Reported taillength: " +juce::String (instance.getTailLengthSeconds()));
+        ut.logMessage ("SupportsDoublePrecision: " + juce::String (instance.supportsDoublePrecisionProcessing() ? "yes" : "no"));
+        ut.logMessage ("Reported latency: " + juce::String (instance.getLatencySamples()));
+        ut.logMessage ("Reported taillength: " + juce::String (instance.getTailLengthSeconds()));
     }
 };
 
@@ -49,7 +49,7 @@ struct PluginPrgramsTest    : public PluginTest
     void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const int numPrograms = instance.getNumPrograms();
-        ut.logMessage ("Num programs: " +juce::String (numPrograms));
+        ut.logMessage ("Num programs: " + juce::String (numPrograms));
 
         for (int i = 0; i < numPrograms; ++i)
             ut.logVerboseMessage (juce::String ("Program 123 name: XYZ")
@@ -67,13 +67,13 @@ struct PluginPrgramsTest    : public PluginTest
             for (int i = 0; i < 5; ++i)
             {
                 const int programNum = r.nextInt (numPrograms);
-                ut.logVerboseMessage ("Changing program to: " +juce::String (programNum));
+                ut.logVerboseMessage ("Changing program to: " + juce::String (programNum));
                 instance.setCurrentProgram (programNum);
             }
 
             if (currentProgram >= 0)
             {
-                ut.logVerboseMessage ("Resetting program to: " +juce::String (currentProgram));
+                ut.logVerboseMessage ("Resetting program to: " + juce::String (currentProgram));
                 instance.setCurrentProgram (currentProgram);
             }
             else
@@ -429,7 +429,7 @@ struct AutomationTest  : public PluginTest
                 if (subnormalsAreErrors)
                     ut.expectEquals (countInfs (ab), 0, "Submnormals found in buffer");
                 else if (subnormals > 0)
-                    ut.logMessage ("!!! WARNGING: " +juce::String (countSubnormals (ab)) + " submnormals found in buffer");
+                    ut.logMessage ("!!! WARNGING: " + juce::String (countSubnormals (ab)) + " submnormals found in buffer");
             }
         }
     }
@@ -490,8 +490,8 @@ namespace ParameterHelpers
         const bool isMetaParameter = parameter.isMetaParameter();
         const auto category = parameter.getCategory();
 
-        #define LOGP(x) JUCE_STRINGIFY(x) + " - " +juce::String (x) + ", "
-        #define LOGP_B(x) JUCE_STRINGIFY(x) + " - " +juce::String (static_cast<int> (x)) + ", "
+        #define LOGP(x) JUCE_STRINGIFY(x) + " - " + juce::String (x) + ", "
+        #define LOGP_B(x) JUCE_STRINGIFY(x) + " - " + juce::String (static_cast<int> (x)) + ", "
         ut.logVerboseMessage (juce::String ("Parameter info: ")
                               + LOGP(index)
                               + LOGP(paramName)
@@ -530,7 +530,7 @@ struct AutomatableParametersTest  : public PluginTest
     {
         for (auto parameter : getNonBypassAutomatableParameters (instance))
         {
-            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") +juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
+            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") + juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
 
             ParameterHelpers::testParameterInfo (ut, *parameter);
             ParameterHelpers::testParameterDefaults (ut, *parameter);
@@ -552,7 +552,7 @@ struct AllParametersTest    : public PluginTest
     {
         for (auto parameter : getNonBypassAutomatableParameters (instance))
         {
-            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") +juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
+            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") + juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
 
             ParameterHelpers::testParameterInfo (ut, *parameter);
             ParameterHelpers::testParameterDefaults (ut, *parameter);

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -25,13 +25,13 @@ struct PluginInfoTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         ut.logMessage ("\nPlugin name: " + instance.getName());
         ut.logMessage ("Alternative names: " + instance.getAlternateDisplayNames().joinIntoString ("|"));
-        ut.logMessage ("SupportsDoublePrecision: " + String (instance.supportsDoublePrecisionProcessing() ? "yes" : "no"));
-        ut.logMessage ("Reported latency: " + String (instance.getLatencySamples()));
-        ut.logMessage ("Reported taillength: " + String (instance.getTailLengthSeconds()));
+        ut.logMessage ("SupportsDoublePrecision: " +juce::String (instance.supportsDoublePrecisionProcessing() ? "yes" : "no"));
+        ut.logMessage ("Reported latency: " +juce::String (instance.getLatencySamples()));
+        ut.logMessage ("Reported taillength: " +juce::String (instance.getTailLengthSeconds()));
     }
 };
 
@@ -46,14 +46,14 @@ struct PluginPrgramsTest    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const int numPrograms = instance.getNumPrograms();
-        ut.logMessage ("Num programs: " + String (numPrograms));
+        ut.logMessage ("Num programs: " +juce::String (numPrograms));
 
         for (int i = 0; i < numPrograms; ++i)
-            ut.logVerboseMessage (String ("Program 123 name: XYZ")
-                                  .replace ("123", String (i))
+            ut.logVerboseMessage (juce::String ("Program 123 name: XYZ")
+                                  .replace ("123",juce::String (i))
                                   .replace ("XYZ", instance.getProgramName (i)));
 
         ut.logMessage ("All program names checked");
@@ -67,13 +67,13 @@ struct PluginPrgramsTest    : public PluginTest
             for (int i = 0; i < 5; ++i)
             {
                 const int programNum = r.nextInt (numPrograms);
-                ut.logVerboseMessage ("Changing program to: " + String (programNum));
+                ut.logVerboseMessage ("Changing program to: " +juce::String (programNum));
                 instance.setCurrentProgram (programNum);
             }
 
             if (currentProgram >= 0)
             {
-                ut.logVerboseMessage ("Resetting program to: " + String (currentProgram));
+                ut.logVerboseMessage ("Resetting program to: " +juce::String (currentProgram));
                 instance.setCurrentProgram (currentProgram);
             }
             else
@@ -96,7 +96,7 @@ struct EditorTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         if (instance.hasEditor())
         {
@@ -130,7 +130,7 @@ struct EditorWhilstProcessingTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         if (instance.hasEditor())
         {
@@ -142,12 +142,12 @@ struct EditorWhilstProcessingTest   : public PluginTest
             jassert (sampleRates.size() > 0 && blockSizes.size() > 0);
             callPrepareToPlayOnMessageThreadIfVST3 (instance, sampleRates[0], blockSizes[0]);
 
-            const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-            AudioBuffer<float> ab (numChannelsRequired, instance.getBlockSize());
-            MidiBuffer mb;
+            const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+            juce::AudioBuffer<float> ab (numChannelsRequired, instance.getBlockSize());
+            juce::MidiBuffer mb;
 
 
-            WaitableEvent threadStartedEvent;
+            juce::WaitableEvent threadStartedEvent;
             std::atomic<bool> shouldProcess { true };
 
             auto processThread = std::async (std::launch::async,
@@ -185,7 +185,7 @@ struct AudioProcessingTest  : public PluginTest
     {
     }
 
-    static void runAudioProcessingTest (PluginTests& ut, AudioPluginInstance& instance,
+    static void runAudioProcessingTest (PluginTests& ut, juce::AudioPluginInstance& instance,
                                         bool callReleaseResourcesBeforeSampleRateChange)
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
@@ -203,25 +203,25 @@ struct AudioProcessingTest  : public PluginTest
         {
             for (auto bs : blockSizes)
             {
-                ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                                   .replace ("SR", String (sr, 0), false)
-                                   .replace ("BS", String (bs), false));
+                ut.logMessage (juce::String ("Testing with sample rate [SR] and block size [BS]")
+                                   .replace ("SR",juce::String (sr, 0), false)
+                                   .replace ("BS",juce::String (bs), false));
 
                 if (callReleaseResourcesBeforeSampleRateChange)
                     callReleaseResourcesOnMessageThreadIfVST3 (instance);
 
                 callPrepareToPlayOnMessageThreadIfVST3 (instance, sr, bs);
 
-                const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs);
-                MidiBuffer mb;
+                const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+                juce::AudioBuffer<float> ab (numChannelsRequired, bs);
+                juce::MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
                 const int noteChannel = r.nextInt ({ 1, 17 });
                 const int noteNumber = r.nextInt (128);
 
                 if (isPluginInstrument)
-                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs));
+                    addNoteOn (mb, noteChannel, noteNumber, juce::jmin (10, bs));
 
                 for (int i = 0; i < numBlocks; ++i)
                 {
@@ -241,7 +241,7 @@ struct AudioProcessingTest  : public PluginTest
         }
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         runAudioProcessingTest (ut, instance, true);
     }
@@ -262,7 +262,7 @@ struct NonReleasingAudioProcessingTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         AudioProcessingTest::runAudioProcessingTest (ut, instance, false);
     }
@@ -279,7 +279,7 @@ struct PluginStateTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         auto r = ut.getRandom();
 
@@ -306,7 +306,7 @@ struct PluginStateTestRestoration   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         auto r = ut.getRandom();
 
@@ -348,7 +348,7 @@ struct AutomationTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const bool subnormalsAreErrors = ut.getOptions().strictnessLevel > 5;
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
@@ -367,25 +367,25 @@ struct AutomationTest  : public PluginTest
             for (auto bs : blockSizes)
             {
                 const int subBlockSize = 32;
-                ut.logMessage (String ("Testing with sample rate [SR] and block size [BS] and sub-block size [SB]")
-                                   .replace ("SR", String (sr, 0), false)
-                                   .replace ("BS", String (bs), false)
-                                   .replace ("SB", String (subBlockSize), false));
+                ut.logMessage (juce::String ("Testing with sample rate [SR] and block size [BS] and sub-block size [SB]")
+                                   .replace ("SR",juce::String (sr, 0), false)
+                                   .replace ("BS",juce::String (bs), false)
+                                   .replace ("SB",juce::String (subBlockSize), false));
 
                 callReleaseResourcesOnMessageThreadIfVST3 (instance);
                 callPrepareToPlayOnMessageThreadIfVST3 (instance, sr, bs);
 
                 int numSamplesDone = 0;
-                const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs);
-                MidiBuffer mb;
+                const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+                juce::AudioBuffer<float> ab (numChannelsRequired, bs);
+                juce::MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
                 const int noteChannel = r.nextInt ({ 1, 17 });
                 const int noteNumber = r.nextInt (128);
 
                 if (isPluginInstrument)
-                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, subBlockSize));
+                    addNoteOn (mb, noteChannel, noteNumber, juce::jmin (10, subBlockSize));
 
                 for (;;)
                 {
@@ -393,7 +393,7 @@ struct AutomationTest  : public PluginTest
                     {
                         auto parameters = getNonBypassAutomatableParameters (instance);
 
-                        for (int i = 0; i < jmin (10, parameters.size()); ++i)
+                        for (int i = 0; i < juce::jmin (10, parameters.size()); ++i)
                         {
                             const int paramIndex = r.nextInt (parameters.size());
                             parameters[paramIndex]->setValue (r.nextFloat());
@@ -401,13 +401,13 @@ struct AutomationTest  : public PluginTest
                     }
 
                     // Create a sub-buffer and process
-                    const int numSamplesThisTime = jmin (subBlockSize, bs - numSamplesDone);
+                    const int numSamplesThisTime = juce::jmin (subBlockSize, bs - numSamplesDone);
 
                     // Trigger a note off in the last sub block
                     if (isPluginInstrument && (bs - numSamplesDone) <= subBlockSize)
-                        addNoteOff (mb, noteChannel, noteNumber, jmin (10, subBlockSize));
+                        addNoteOff (mb, noteChannel, noteNumber, juce::jmin (10, subBlockSize));
 
-                    AudioBuffer<float> subBuffer (ab.getArrayOfWritePointers(),
+                    juce::AudioBuffer<float> subBuffer (ab.getArrayOfWritePointers(),
                                                   ab.getNumChannels(),
                                                   numSamplesDone,
                                                   numSamplesThisTime);
@@ -429,7 +429,7 @@ struct AutomationTest  : public PluginTest
                 if (subnormalsAreErrors)
                     ut.expectEquals (countInfs (ab), 0, "Submnormals found in buffer");
                 else if (subnormals > 0)
-                    ut.logMessage ("!!! WARNGING: " + String (countSubnormals (ab)) + " submnormals found in buffer");
+                    ut.logMessage ("!!! WARNGING: " +juce::String (countSubnormals (ab)) + " submnormals found in buffer");
             }
         }
     }
@@ -447,7 +447,7 @@ struct EditorAutomationTest : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const ScopedEditorShower editor (instance);
 
@@ -462,7 +462,7 @@ struct EditorAutomationTest : public PluginTest
                 parameter->setValue (r.nextFloat());
 
             ut.resetTimeout();
-            Thread::sleep (10);
+            juce::Thread::sleep (10);
         }
     }
 };
@@ -473,26 +473,26 @@ static EditorAutomationTest editorAutomationTest;
 //==============================================================================
 namespace ParameterHelpers
 {
-    static void testParameterInfo (PluginTests& ut, AudioProcessorParameter& parameter)
+    static void testParameterInfo (PluginTests& ut, juce::AudioProcessorParameter& parameter)
     {
         const int index = parameter.getParameterIndex();
-        const String paramName = parameter.getName (512);
+        const juce::String paramName = parameter.getName (512);
 
         const float defaultValue = parameter.getDefaultValue();
-        const String label = parameter.getLabel();
+        const juce::String label = parameter.getLabel();
         const int numSteps = parameter.getNumSteps();
         const bool isDiscrete = parameter.isDiscrete();
         const bool isBoolean = parameter.isBoolean();
-        const StringArray allValueStrings = parameter.getAllValueStrings();
+        const juce::StringArray allValueStrings = parameter.getAllValueStrings();
 
         const bool isOrientationInverted = parameter.isOrientationInverted();
         const bool isAutomatable = parameter.isAutomatable();
         const bool isMetaParameter = parameter.isMetaParameter();
         const auto category = parameter.getCategory();
 
-        #define LOGP(x) JUCE_STRINGIFY(x) + " - " + String (x) + ", "
-        #define LOGP_B(x) JUCE_STRINGIFY(x) + " - " + String (static_cast<int> (x)) + ", "
-        ut.logVerboseMessage (String ("Parameter info: ")
+        #define LOGP(x) JUCE_STRINGIFY(x) + " - " +juce::String (x) + ", "
+        #define LOGP_B(x) JUCE_STRINGIFY(x) + " - " +juce::String (static_cast<int> (x)) + ", "
+        ut.logVerboseMessage (juce::String ("Parameter info: ")
                               + LOGP(index)
                               + LOGP(paramName)
                               + LOGP(defaultValue)
@@ -507,14 +507,14 @@ namespace ParameterHelpers
                               + "all value strings - " + allValueStrings.joinIntoString ("|"));
     }
 
-    static void testParameterDefaults (PluginTests& ut, AudioProcessorParameter& parameter)
+    static void testParameterDefaults (PluginTests& ut, juce::AudioProcessorParameter& parameter)
     {
-        ut.logVerboseMessage ("Testing accessers");
+        ut.logVerboseMessage ("Testing accessors");
 
         const float value = parameter.getValue();
-        const String text = parameter.getText (value, 1024);
+        const juce::String text = parameter.getText (value, 1024);
         const float valueForText = parameter.getValueForText (text);
-        const String currentValueAsText = parameter.getCurrentValueAsText();
+        const juce::String currentValueAsText = parameter.getCurrentValueAsText();
         ignoreUnused (value, text, valueForText, currentValueAsText);
     }
 }
@@ -526,11 +526,11 @@ struct AutomatableParametersTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         for (auto parameter : getNonBypassAutomatableParameters (instance))
         {
-            ut.logVerboseMessage (String ("\nTesting parameter: ") + String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
+            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") +juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
 
             ParameterHelpers::testParameterInfo (ut, *parameter);
             ParameterHelpers::testParameterDefaults (ut, *parameter);
@@ -548,11 +548,11 @@ struct AllParametersTest    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         for (auto parameter : getNonBypassAutomatableParameters (instance))
         {
-            ut.logVerboseMessage (String ("\nTesting parameter: ") + String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
+            ut.logVerboseMessage (juce::String ("\nTesting parameter: ") +juce::String (parameter->getParameterIndex()) + " - " + parameter->getName (512));
 
             ParameterHelpers::testParameterInfo (ut, *parameter);
             ParameterHelpers::testParameterDefaults (ut, *parameter);
@@ -575,7 +575,7 @@ struct BackgroundThreadStateTest    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         auto r = ut.getRandom();
         ScopedEditorShower editor (instance);
@@ -593,7 +593,7 @@ struct BackgroundThreadStateTest    : public PluginTest
         callSetStateInformationOnMessageThreadIfVST3 (instance, originalState);
 
         // Allow for async reaction to state changes
-        Thread::sleep (2000);
+        juce::Thread::sleep (2000);
     }
 };
 
@@ -602,7 +602,7 @@ static BackgroundThreadStateTest backgroundThreadStateTest;
 
 //==============================================================================
 /** Sets plugin parameters from a background thread and the main thread at the
-    same time, as if via host automation and UI simultenously.
+    same time, as if via host automation and UI simultaneously.
 */
 struct ParameterThreadSafetyTest    : public PluginTest
 {
@@ -611,16 +611,16 @@ struct ParameterThreadSafetyTest    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
-        WaitableEvent startWaiter, endWaiter;
+        juce::WaitableEvent startWaiter, endWaiter;
         auto r = ut.getRandom();
         auto parameters = getNonBypassAutomatableParameters (instance);
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
         const int numBlocks = 500;
 
         // This emulates the plugin itself setting a value for example from a slider within its UI
-        MessageManager::callAsync ([&, threadRandom = r]() mutable
+        juce::MessageManager::callAsync ([&, threadRandom = r]() mutable
                                    {
                                        startWaiter.signal();
 
@@ -635,16 +635,16 @@ struct ParameterThreadSafetyTest    : public PluginTest
         callReleaseResourcesOnMessageThreadIfVST3 (instance);
         callPrepareToPlayOnMessageThreadIfVST3 (instance, 44100.0, blockSize);
 
-        const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-        AudioBuffer<float> ab (numChannelsRequired, blockSize);
-        MidiBuffer mb;
+        const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+        juce::AudioBuffer<float> ab (numChannelsRequired, blockSize);
+        juce::MidiBuffer mb;
 
         // Add a random note on if the plugin is a synth
         const int noteChannel = r.nextInt ({ 1, 17 });
         const int noteNumber = r.nextInt (128);
 
         if (isPluginInstrument)
-            addNoteOn (mb, noteChannel, noteNumber, jmin (10, blockSize));
+            addNoteOn (mb, noteChannel, noteNumber, juce::jmin (10, blockSize));
 
         startWaiter.wait();
 
@@ -679,7 +679,7 @@ struct AUvalTest    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const auto desc = instance.getPluginDescription();
 
@@ -746,7 +746,7 @@ struct VST3validator    : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const auto desc = instance.getPluginDescription();
 
@@ -755,7 +755,7 @@ struct VST3validator    : public PluginTest
 
         auto vst3Validator = ut.getOptions().vst3Validator;
 
-        if (vst3Validator == File())
+        if (vst3Validator == juce::File())
         {
             ut.logMessage ("INFO: Skipping vst3 validator as validator path hasn't been set");
             return;

--- a/Source/tests/BusTests.cpp
+++ b/Source/tests/BusTests.cpp
@@ -23,7 +23,7 @@ struct BasicBusTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const ScopedPluginDeinitialiser deinitialiser (instance);
         const auto currentLayout = instance.getBusesLayout();
@@ -33,8 +33,8 @@ struct BasicBusTest   : public PluginTest
             listBuses (ut, instance, true);
             listBuses (ut, instance, false);
 
-            ut.logMessage ("Main bus num input channels: " + String (instance.getMainBusNumInputChannels()));
-            ut.logMessage ("Main bus num output channels: " + String (instance.getMainBusNumOutputChannels()));
+            ut.logMessage ("Main bus num input channels: " +juce::String (instance.getMainBusNumInputChannels()));
+            ut.logMessage ("Main bus num output channels: " +juce::String (instance.getMainBusNumOutputChannels()));
         }
 
         ut.beginTest ("Enabling all buses");
@@ -52,15 +52,15 @@ struct BasicBusTest   : public PluginTest
         ut.beginTest ("Restoring default layout");
         {
             ut.expect (instance.setBusesLayout (currentLayout), "Unable to restore default layout");
-            ut.logMessage ("Main bus num input channels: " + String (instance.getMainBusNumInputChannels()));
-            ut.logMessage ("Main bus num output channels: " + String (instance.getMainBusNumOutputChannels()));
+            ut.logMessage ("Main bus num input channels: " +juce::String (instance.getMainBusNumInputChannels()));
+            ut.logMessage ("Main bus num output channels: " +juce::String (instance.getMainBusNumOutputChannels()));
         }
     }
 
-    static void listBuses (PluginTests& ut, AudioPluginInstance& instance, bool inputs)
+    static void listBuses (PluginTests& ut, juce::AudioPluginInstance& instance, bool inputs)
     {
         const int numBuses = instance.getBusCount (inputs);
-        StringArray namedLayouts, discreteLayouts;
+        juce::StringArray namedLayouts, discreteLayouts;
 
         for (int busNum = 0; busNum < numBuses; ++busNum)
         {
@@ -75,34 +75,34 @@ struct BasicBusTest   : public PluginTest
         }
 
         ut.logMessage (inputs ? "Inputs:" : "Outputs:");
-        ut.logMessage ("\tNamed layouts: " + (namedLayouts.isEmpty() ? String ("None") : namedLayouts.joinIntoString (", ")));
-        ut.logMessage ("\tDiscrete layouts: " + (discreteLayouts.isEmpty() ? String ("None") : discreteLayouts.joinIntoString (", ")));
+        ut.logMessage ("\tNamed layouts: " + (namedLayouts.isEmpty() ?juce::String ("None") : namedLayouts.joinIntoString (", ")));
+        ut.logMessage ("\tDiscrete layouts: " + (discreteLayouts.isEmpty() ?juce::String ("None") : discreteLayouts.joinIntoString (", ")));
     }
 
-    static Array<AudioChannelSet> supportedLayoutsWithNamedChannels (AudioProcessor::Bus& bus)
+    static juce::Array<juce::AudioChannelSet> supportedLayoutsWithNamedChannels (juce::AudioProcessor::Bus& bus)
     {
-        Array<AudioChannelSet> sets;
+        juce::Array<juce::AudioChannelSet> sets;
 
-        for (int i = 0; i <= AudioChannelSet::maxChannelsOfNamedLayout; ++i)
+        for (int i = 0; i <= juce::AudioChannelSet::maxChannelsOfNamedLayout; ++i)
         {
-            AudioChannelSet set;
+            juce::AudioChannelSet set;
 
-            if (! (set = AudioChannelSet::namedChannelSet  (i)).isDisabled() && bus.isLayoutSupported (set))
+            if (! (set = juce::AudioChannelSet::namedChannelSet  (i)).isDisabled() && bus.isLayoutSupported (set))
                 sets.add (set);
         }
 
         return sets;
     }
 
-    static Array<AudioChannelSet> supportedLayoutsWithDiscreteChannels (AudioProcessor::Bus& bus)
+    static juce::Array<juce::AudioChannelSet> supportedLayoutsWithDiscreteChannels (juce::AudioProcessor::Bus& bus)
     {
-        Array<AudioChannelSet> sets;
+        juce::Array<juce::AudioChannelSet> sets;
 
         for (int i = 0; i <= 32; ++i)
         {
-            AudioChannelSet set;
+            juce::AudioChannelSet set;
 
-            if (! (set = AudioChannelSet::discreteChannels (i)).isDisabled() && bus.isLayoutSupported (set))
+            if (! (set = juce::AudioChannelSet::discreteChannels (i)).isDisabled() && bus.isLayoutSupported (set))
                 sets.add (set);
         }
 

--- a/Source/tests/BusTests.cpp
+++ b/Source/tests/BusTests.cpp
@@ -33,8 +33,8 @@ struct BasicBusTest   : public PluginTest
             listBuses (ut, instance, true);
             listBuses (ut, instance, false);
 
-            ut.logMessage ("Main bus num input channels: " +juce::String (instance.getMainBusNumInputChannels()));
-            ut.logMessage ("Main bus num output channels: " +juce::String (instance.getMainBusNumOutputChannels()));
+            ut.logMessage ("Main bus num input channels: " + juce::String (instance.getMainBusNumInputChannels()));
+            ut.logMessage ("Main bus num output channels: " + juce::String (instance.getMainBusNumOutputChannels()));
         }
 
         ut.beginTest ("Enabling all buses");
@@ -52,8 +52,8 @@ struct BasicBusTest   : public PluginTest
         ut.beginTest ("Restoring default layout");
         {
             ut.expect (instance.setBusesLayout (currentLayout), "Unable to restore default layout");
-            ut.logMessage ("Main bus num input channels: " +juce::String (instance.getMainBusNumInputChannels()));
-            ut.logMessage ("Main bus num output channels: " +juce::String (instance.getMainBusNumOutputChannels()));
+            ut.logMessage ("Main bus num input channels: " + juce::String (instance.getMainBusNumInputChannels()));
+            ut.logMessage ("Main bus num output channels: " + juce::String (instance.getMainBusNumOutputChannels()));
         }
     }
 

--- a/Source/tests/EditorTests.cpp
+++ b/Source/tests/EditorTests.cpp
@@ -26,7 +26,7 @@ struct EditorStressTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         if (instance.hasEditor())
         {
@@ -59,7 +59,7 @@ struct EditorDPITest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         if (instance.hasEditor())
         {

--- a/Source/tests/ExtremeTests.cpp
+++ b/Source/tests/ExtremeTests.cpp
@@ -23,7 +23,7 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         const bool isPluginInstrument = instance.getPluginDescription().isInstrument;
 
@@ -40,22 +40,22 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
         {
             for (auto bs : blockSizes)
             {
-                ut.logMessage (String ("Testing with sample rate [SR] and block size [BS]")
-                                   .replace ("SR", String (sr, 0), false)
-                                   .replace ("BS", String (bs), false));
+                ut.logMessage (juce::String ("Testing with sample rate [SR] and block size [BS]")
+                                   .replace ("SR",juce::String (sr, 0), false)
+                                   .replace ("BS",juce::String (bs), false));
                 instance.releaseResources();
                 instance.prepareToPlay (sr, bs);
 
-                const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, bs);
-                MidiBuffer mb;
+                const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+                juce::AudioBuffer<float> ab (numChannelsRequired, bs);
+                juce::MidiBuffer mb;
 
                 // Add a random note on if the plugin is a synth
                 const int noteChannel = r.nextInt ({ 1, 17 });
                 const int noteNumber = r.nextInt (128);
 
                 if (isPluginInstrument)
-                    addNoteOn (mb, noteChannel, noteNumber, jmin (10, bs - 1));
+                    addNoteOn (mb, noteChannel, noteNumber, juce::jmin (10, bs - 1));
 
                 for (int i = 0; i < numBlocks; ++i)
                 {
@@ -73,7 +73,7 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
                     mb.clear();
 
                     auto& ai = getAllocatorInterceptor();
-                    ut.expect (! ai.getAndClearAllocationViolation(), "Allocations occured in audio thread: " + String (ai.getAndClearNumAllocationViolations()));
+                    ut.expect (! ai.getAndClearAllocationViolation(), "Allocations occurred in audio thread: " +juce::String (ai.getAndClearNumAllocationViolations()));
 
                     ut.expectEquals (countNaNs (ab), 0, "NaNs found in buffer");
                     ut.expectEquals (countInfs (ab), 0, "Infs found in buffer");
@@ -94,7 +94,7 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         if (! canRunTest (instance))
         {
@@ -119,16 +119,16 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
             for (auto preparedBlockSize : blockSizes)
             {
                 const auto processingBlockSize = preparedBlockSize * 2;
-                ut.logMessage (String ("Preparing with sample rate [SR] and block size [BS], processing with block size [BSP]")
-                                   .replace ("SR", String (sr, 0), false)
-                                   .replace ("BSP", String (processingBlockSize), false)
-                                   .replace ("BS", String (preparedBlockSize), false));
+                ut.logMessage (juce::String ("Preparing with sample rate [SR] and block size [BS], processing with block size [BSP]")
+                                   .replace ("SR",juce::String (sr, 0), false)
+                                   .replace ("BSP",juce::String (processingBlockSize), false)
+                                   .replace ("BS",juce::String (preparedBlockSize), false));
                 instance.releaseResources();
                 instance.prepareToPlay (sr, preparedBlockSize);
 
-                const int numChannelsRequired = jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
-                AudioBuffer<float> ab (numChannelsRequired, processingBlockSize);
-                MidiBuffer mb;
+                const int numChannelsRequired = juce::jmax (instance.getTotalNumInputChannels(), instance.getTotalNumOutputChannels());
+                juce::AudioBuffer<float> ab (numChannelsRequired, processingBlockSize);
+                juce::MidiBuffer mb;
 
                 for (int i = 0; i < 10; ++i)
                 {
@@ -145,7 +145,7 @@ struct LargerThanPreparedBlockSizeTest   : public PluginTest
     }
 
 private:
-    static bool canRunTest (const AudioPluginInstance& instance)
+    static bool canRunTest (const juce::AudioPluginInstance& instance)
     {
         const auto format = instance.getPluginDescription().pluginFormatName;
 

--- a/Source/tests/ExtremeTests.cpp
+++ b/Source/tests/ExtremeTests.cpp
@@ -73,7 +73,7 @@ struct AllocationsInRealTimeThreadTest  : public PluginTest
                     mb.clear();
 
                     auto& ai = getAllocatorInterceptor();
-                    ut.expect (! ai.getAndClearAllocationViolation(), "Allocations occurred in audio thread: " +juce::String (ai.getAndClearNumAllocationViolations()));
+                    ut.expect (! ai.getAndClearAllocationViolation(), "Allocations occurred in audio thread: " + juce::String (ai.getAndClearNumAllocationViolations()));
 
                     ut.expectEquals (countNaNs (ab), 0, "NaNs found in buffer");
                     ut.expectEquals (countInfs (ab), 0, "Infs found in buffer");

--- a/Source/tests/ParameterFuzzTests.cpp
+++ b/Source/tests/ParameterFuzzTests.cpp
@@ -23,17 +23,17 @@ struct FuzzParametersTest  : public PluginTest
     {
     }
 
-    void runTest (PluginTests& ut, AudioPluginInstance& instance) override
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
     {
         for (auto parameter : getNonBypassAutomatableParameters (instance))
             fuzzTestParameter (ut, *parameter);
     }
 
 private:
-    void fuzzTestParameter (PluginTests& ut, AudioProcessorParameter& parameter)
+    void fuzzTestParameter (PluginTests& ut, juce::AudioProcessorParameter& parameter)
     {
         auto r = ut.getRandom();
-        ut.logVerboseMessage (String ("Fuzz testing parameter: ") + String (parameter.getParameterIndex()) + " - " + parameter.getName (512));
+        ut.logVerboseMessage (juce::String ("Fuzz testing parameter: ") +juce::String (parameter.getParameterIndex()) + " - " + parameter.getName (512));
 
         for (int i = 0; i < 5; ++i)
         {
@@ -42,8 +42,8 @@ private:
             parameter.setValue (value);
             const float v = parameter.getValue();
 
-            const String currentValueAsText = parameter.getCurrentValueAsText();
-            const String text = parameter.getText (value, 1024);
+            const juce::String currentValueAsText = parameter.getCurrentValueAsText();
+            const juce::String text = parameter.getText (value, 1024);
             const float valueForText = parameter.getValueForText (text);
             ignoreUnused (v, text, valueForText, currentValueAsText);
         }

--- a/Source/tests/ParameterFuzzTests.cpp
+++ b/Source/tests/ParameterFuzzTests.cpp
@@ -33,7 +33,7 @@ private:
     void fuzzTestParameter (PluginTests& ut, juce::AudioProcessorParameter& parameter)
     {
         auto r = ut.getRandom();
-        ut.logVerboseMessage (juce::String ("Fuzz testing parameter: ") +juce::String (parameter.getParameterIndex()) + " - " + parameter.getName (512));
+        ut.logVerboseMessage (juce::String ("Fuzz testing parameter: ") + juce::String (parameter.getParameterIndex()) + " - " + parameter.getName (512));
 
         for (int i = 0; i < 5; ++i)
         {


### PR DESCRIPTION
green build: https://github.com/sudara/pluginval/actions/runs/2940195250

Does what it says on the box:

1. Removes JuceHeader.h and replaces with minimum necessary JUCE headers.
2. Qualifies everything juce with `juce::` namespace.
3. Fixed one or two typos
4. Adds some Clion IDE stuff to .gitignore

That's it! Took 1 hr. Fun fact: my `v` key actually fell off my mechanical keyboard from all the cmd-v-ing :) 

