### PR TITLE
Increase default timeout to 60s

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -55,7 +55,7 @@ namespace
 
     int64 getTimeoutMs()
     {
-        return getAppPreferences().getIntValue ("timeoutMs", 30000);
+        return getAppPreferences().getIntValue ("timeoutMs", 60000);
     }
 
     void setVerboseLogging (bool verbose)

--- a/Source/PluginTests.h
+++ b/Source/PluginTests.h
@@ -28,7 +28,7 @@ struct PluginTests : public UnitTest
     {
         int strictnessLevel = 5;            /**< Max test level to run. */
         int64 randomSeed = 0;               /**< The seed to use for the tests, 0 signifies a randomly generated seed. */
-        int64 timeoutMs = 30000;            /**< Timeout after which to kill the test. */
+        int64 timeoutMs = 60000;            /**< Timeout after which to kill the test. */
         bool verbose = false;               /**< Whether or not to log additional information. */
         int numRepeats = 1;                 /**< The number of times to repeat the tests. */
         bool randomiseTestOrder = false;    /**< Whether to randomise the order of the tests in each repeat. */


### PR DESCRIPTION
Waiting for green build here: https://github.com/sudara/pluginval/actions/runs/2944471209

This PR bumps the default timeout to 60s from 30s. 

I'm seeing pluginval regularly killed in CI (sometimes with exit code 137) — it seems to regularly take over 30s to complete at strictness level 10, especially on macOS. 30s seems too optimistic for real-world plugins, especially now with the additional auval stuff added.

Pluginval's own [pluginval runs are taking longer than 30s (on somewhat trivial plugins)](https://github.com/Tracktion/pluginval/runs/7770664259?check_suite_focus=true) (not totally sure, but i think they might be getting killed before succeeding too, I'm not seeing that final summary that with "All tests completed," the timing info, etc)