### PR TITLE
Log signals like SIGILL and SIGSEGV before kill -9ing the process

### DIFF
--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -40,18 +40,20 @@ static void hideDockIcon()
 
 //==============================================================================
 #if JUCE_MAC
-static void killWithoutMercy (int)
+static void kill9WithSomeMercy (int signal)
 {
-    kill (getpid(), SIGKILL);
+   juce::Logger::writeToLog ("pluginval received " + juce::String(::strsignal(signal)) + ", exiting immediately");
+   kill (getpid(), SIGKILL);
 }
 
+// Avoid showing the macOS crash dialog, which can cause the process to hang
 static void setupSignalHandling()
 {
     const int signals[] = { SIGFPE, SIGILL, SIGSEGV, SIGBUS, SIGABRT };
 
     for (int i = 0; i < juce::numElementsInArray (signals); ++i)
     {
-        ::signal (signals[i], killWithoutMercy);
+        ::signal (signals[i], kill9WithSomeMercy);
         ::siginterrupt (signals[i], 1);
     }
 }


### PR DESCRIPTION
This PR makes it easier to debug crashes on macOS, especially in CI.

Build status: https://github.com/sudara/pluginval/actions/runs/3011554276

The `137` exit code I was seeing in #94 was a red herring. There was no issue with timeouts, the process was being killed for other reasons, which were swallowed by the `killWithoutMercy` macOS logic (in place to make sure the process doesn't hang in CI when the crash dialog was shown).

This PR just logs what the kill signal was before `kill -9`'ing the process.

But it has an important side effect — it allows (via log flushing?) the actual issue to be logged before the process terminates. The result is an actionable lead from crashes in CI on macOS.


Before
```
Starting tests in: pluginval / Editor...
/Users/runner/work/_temp/4e3e4ee5-27be-4255-9044-dad969ee8a7b.sh: line 3: 18778 Killed: 9               pluginval.app/Contents/MacOS/pluginval --strictness-level 10 --timeout-ms 110000 --verbose --validate "***_artefacts/Release/VST3/***.vst3"
Error: Process completed with exit code 137.
```

After
```
Fuzz testing parameter: 120 - ***
libc++abi: terminating with uncaught exception of type std::__1::system_error: mutex lock failed: Invalid argument
pluginval received Abort trap: 6, exiting immediately
/Users/runner/work/_temp/10c6a3d7-e6c9-4cdd-a018-0bdbdac29ae2.sh: line 3: 14546 Killed: 9               pluginval.app/Contents/MacOS/pluginval --strictness-level 10 --timeout-ms 110000 --verbose --validate "***_artefacts/Release/VST3/***.vst3"
Error: Process completed with exit code 137.
```

As far as the actual crash, sounds like a threading issue? It seems to happen randomly throughout the testing. A job for another day...
