### PR TITLE
Avoid Thread Sanitizer complaints about data races on cout

### DIFF
--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -78,7 +78,10 @@ void CommandLineValidator::validate (const juce::String& fileOrID, PluginTests::
     validator = std::make_unique<ValidationPass> (fileOrID, options, ValidationType::inProcess,
                                                   [] (auto id)
                                                   {
-                                                      std::cout << "Started validating: " << id << std::endl;
+                                                      juce::MessageManager::callAsync ([id]
+                                                      {
+                                                          std::cout << "Started validating: " << id << std::endl;
+                                                      });
                                                   },
                                                   [] (auto, uint32_t exitCode)
                                                   {
@@ -89,7 +92,10 @@ void CommandLineValidator::validate (const juce::String& fileOrID, PluginTests::
                                                   },
                                                   [] (auto m)
                                                   {
-                                                      std::cout << m << std::flush;
+                                                      juce::MessageManager::callAsync ([m]
+                                                      {
+                                                          std::cout << m << std::flush;
+                                                      });
                                                   });
 }
 


### PR DESCRIPTION
Previously, the validator thread could try to write to cout at the same time as the main thread. Until we can use std::osyncstream, it's probably safer to limit output to the main thread.