### PR TITLE
Snap values for discrete parameters

### DIFF
--- a/Source/TestUtilities.h
+++ b/Source/TestUtilities.h
@@ -54,6 +54,21 @@ static inline juce::Array<juce::AudioProcessorParameter*> getNonBypassAutomatabl
 }
 
 //==============================================================================
+static inline void randomizeParameter (juce::Random& r, juce::AudioProcessorParameter* parameter)
+{
+    auto newValue = r.nextFloat();
+
+    // snap to legal value
+    if (parameter->isDiscrete())
+    {
+        auto maxValue = static_cast<float>(parameter->getNumSteps() - 1);
+        newValue = std::round(newValue * maxValue) / maxValue;
+    }
+
+    parameter->setValue (newValue);
+}
+
+//==============================================================================
 template<typename UnaryFunction>
 void iterateAudioBuffer (juce::AudioBuffer<float>& ab, UnaryFunction fn)
 {

--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -288,7 +288,7 @@ struct PluginStateTest  : public PluginTest
 
         // Set random parameter values
         for (auto parameter : getNonBypassAutomatableParameters (instance))
-            parameter->setValue (r.nextFloat());
+            randomizeParameter (r, parameter);
 
         // Restore original state
         callSetStateInformationOnMessageThreadIfVST3 (instance, originalState);
@@ -318,8 +318,9 @@ struct PluginStateTestRestoration   : public PluginTest
         // Set random parameter values
         for (auto parameter : getNonBypassAutomatableParameters(instance))
         {
-			const auto originalValue = parameter->getValue();
-            parameter->setValue(r.nextFloat());
+            const auto originalValue = parameter->getValue();
+
+            randomizeParameter (r, parameter);
 
             // Restore original state
             callSetStateInformationOnMessageThreadIfVST3(instance, originalState);
@@ -398,7 +399,7 @@ struct AutomationTest  : public PluginTest
                         for (int i = 0; i < juce::jmin (10, parameters.size()); ++i)
                         {
                             const int paramIndex = r.nextInt (parameters.size());
-                            parameters[paramIndex]->setValue (r.nextFloat());
+                            randomizeParameter (r, parameters[paramIndex]);
                         }
                     }
 
@@ -461,7 +462,7 @@ struct EditorAutomationTest : public PluginTest
         while (--numBlocks >= 0)
         {
             for (auto parameter : parameters)
-                parameter->setValue (r.nextFloat());
+                randomizeParameter (r, parameter);
 
             ut.resetTimeout();
             juce::Thread::sleep (10);
@@ -589,7 +590,7 @@ struct BackgroundThreadStateTest    : public PluginTest
 
         // Set random parameter values
         for (auto parameter : parameters)
-            parameter->setValue (r.nextFloat());
+            randomizeParameter (r, parameter);
 
         // Restore original state
         callSetStateInformationOnMessageThreadIfVST3 (instance, originalState);


### PR DESCRIPTION
When setting random values to discrete parameters, they will be snapped to the nearest legitimate value.
This will subesquently lead to false positives when comparing the value that was read back.

This PR  makes sure, that the test get only legit values set for discrete parameters, especially boolean and choice parameters.