### PR TITLE
`auval -stress` defaults to 20 seconds (vs default 600)

### DIFF
--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -689,7 +689,7 @@ struct AUvalTest    : public PluginTest
             return;
 
         // Use -stress on strictness levels greater than 5
-        const auto cmd = juce::String ("auval -strict STRESS -v ").replace ("STRESS", ut.getOptions().strictnessLevel > 5 ? "-stress" : "")
+        const auto cmd = juce::String ("auval -strict STRESS -v ").replace ("STRESS", ut.getOptions().strictnessLevel > 5 ? "-stress 20" : "")
                             + desc.fileOrIdentifier.fromLastOccurrenceOf ("/", false, false).replace (",", " ");
 
         juce::ChildProcess cp;


### PR DESCRIPTION
Fixes #134 
