### PR TITLE
Pluginval as dependency

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -167,6 +167,33 @@ jobs:
           name: ${{ env.ZIP_FILE_NAME }}
           path: ${{ env.APP_DIR }}/${{ env.ZIP_FILE_NAME }}
 
+  # Test pluginval as a dependency in another JUCE project
+  as_dependency:
+    name: Pluginval as Dependency
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-15, windows-latest]
+        juce: ["8.0.3", "8.0.11"]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libasound2-dev libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libwebkit2gtk-4.1-dev
+
+      - name: Configure
+        run: cmake -B build -S tests/pluginval_as_dependency -DJUCE_VERSION=${{ matrix.juce }}
+
+      - name: Build
+        run: cmake --build build --target pluginval --parallel 4
+
+      - name: Verify
+        run: cmake --build build --target verify_pluginval
+
   # Create release for tagged refs
   deploy:
     if: contains(github.ref, 'tags/v')

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -61,7 +61,7 @@ jobs:
           
           # This needs to be absolute to make action/cache happy
           WORKING_DIR=$(pwd)
-          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/modules/juce/Builds/examples/Plugins" >> $GITHUB_ENV
+          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/_deps/juce-build/examples/Plugins" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: ${{ matrix.name == 'Linux' }}
@@ -112,11 +112,10 @@ jobs:
         with:
           path: ${{ env.PLUGIN_CACHE_PATH }}
           # Increment the version in the key below to manually break plugin cache
-          key: v7-${{ runner.os }}-${{ env.JUCE_SHA1 }}
+          key: v8-${{ runner.os }}-${{ env.JUCE_SHA1 }}
 
       - name: Build JUCE example plugins
         if: steps.cache-plugins.outputs.cache-hit != 'true'
-        working-directory: modules/juce
         shell: bash
         run: |
           cmake -B Builds -DJUCE_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -56,12 +56,11 @@ jobs:
           echo "VERSION=$VERSION" >> $GITHUB_ENV
           echo "APP_DIR=${{ env.BUILD_DIR }}/${{ env.BINARY_NAME }}_artefacts/${{ env.BUILD_TYPE }}" >> $GITHUB_ENV
           echo "ZIP_FILE_NAME=${{ env.BINARY_NAME }}_${{ matrix.name }}.zip" >> $GITHUB_ENV
-          echo "JUCE_SHA1=$(git rev-parse HEAD:modules/juce)" >> $GITHUB_ENV
-          echo "PLUGIN_BUILD_DIR=modules/juce/Builds" >> $GITHUB_ENV
-          
+
           # This needs to be absolute to make action/cache happy
+          # CPM fetches JUCE into the build directory's _deps folder
           WORKING_DIR=$(pwd)
-          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/_deps/juce-build/examples/Plugins" >> $GITHUB_ENV
+          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/${{ env.BUILD_DIR }}/_deps/juce-build/examples/Plugins" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: ${{ matrix.name == 'Linux' }}
@@ -112,7 +111,7 @@ jobs:
         with:
           path: ${{ env.PLUGIN_CACHE_PATH }}
           # Increment the version in the key below to manually break plugin cache
-          key: v8-${{ runner.os }}-${{ env.JUCE_SHA1 }}
+          key: v9-${{ runner.os }}
 
       - name: Build JUCE example plugins
         if: steps.cache-plugins.outputs.cache-hit != 'true'

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -58,9 +58,9 @@ jobs:
           echo "ZIP_FILE_NAME=${{ env.BINARY_NAME }}_${{ matrix.name }}.zip" >> $GITHUB_ENV
 
           # This needs to be absolute to make action/cache happy
-          # CPM fetches JUCE into the build directory's _deps folder
+          # JUCE examples are built from within the CPM-fetched JUCE source directory
           WORKING_DIR=$(pwd)
-          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/${{ env.BUILD_DIR }}/_deps/juce-build/examples/Plugins" >> $GITHUB_ENV
+          echo "PLUGIN_CACHE_PATH=$WORKING_DIR/${{ env.BUILD_DIR }}/_deps/juce-src/Builds/examples/Plugins" >> $GITHUB_ENV
 
       - name: Install dependencies (Linux)
         if: ${{ matrix.name == 'Linux' }}
@@ -115,6 +115,7 @@ jobs:
 
       - name: Build JUCE example plugins
         if: steps.cache-plugins.outputs.cache-hit != 'true'
+        working-directory: ${{ env.BUILD_DIR }}/_deps/juce-src
         shell: bash
         run: |
           cmake -B Builds -DJUCE_BUILD_EXAMPLES=ON -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache .

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,8 +48,6 @@ jobs:
           apt install -y sudo cmake curl tree
 
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - name: Setup Environment Variables
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,7 +88,7 @@ jobs:
       - name: ccache
         uses: hendrikmuhs/ccache-action@v1.2
         with:
-          key: v2-${{ matrix.name }}-${{ env.BUILD_TYPE }}
+          key: v3-${{ matrix.name }}-${{ env.BUILD_TYPE }}
 
       - name: Configure
         shell: bash

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -183,10 +183,10 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libasound2-dev libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libwebkit2gtk-4.1-dev
+          sudo apt-get install -y libasound2-dev libfreetype6-dev libx11-dev libxcomposite-dev libxcursor-dev libxinerama-dev libxrandr-dev mesa-common-dev libwebkit2gtk-4.1-dev ladspa-sdk
 
       - name: Configure
-        run: cmake -B build -S tests/pluginval_as_dependency -DJUCE_VERSION=${{ matrix.juce }}
+        run: cmake -B build -S tests/pluginval_as_dependency -DJUCE_VERSION="${{ matrix.juce }}"
 
       - name: Build
         run: cmake --build build --target pluginval --parallel 4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "modules/juce"]
-	path = modules/juce
-	url = https://github.com/juce-framework/JUCE
-	branch = develop

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,16 +3,24 @@ cmake_minimum_required(VERSION 3.15)
 file(STRINGS VERSION CURRENT_VERSION LIMIT_COUNT 1)
 project(pluginval VERSION ${CURRENT_VERSION})
 
-if (APPLE)
-    # Target OS versions down to 10.11
-    set (CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE INTERNAL "")
+# Executes when not compiling as a "dependency" of another CMake project
+if (pluginval_IS_TOP_LEVEL)
+    if (APPLE)
+        # Target OS versions down to 10.11
+        set (CMAKE_OSX_DEPLOYMENT_TARGET "10.11" CACHE INTERNAL "")
 
-    # Uncomment to produce a universal binary
-    # set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
-    set(PLUGINVAL_ENABLE_RTCHECK ON)
-elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
-    # Disable rtcheck on Linux for now until further testing on real Linux systems has been done
-    # set(PLUGINVAL_ENABLE_RTCHECK ON)
+        # Uncomment to produce a universal binary
+        # set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
+        set(PLUGINVAL_ENABLE_RTCHECK ON)
+    elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+        # Disable rtcheck on Linux for now until further testing on real Linux systems has been done
+        # set(PLUGINVAL_ENABLE_RTCHECK ON)
+    endif()
+else()
+    # compiling as a "dependency" of another JUCE CMake project
+    if (NOT COMMAND juce_add_module)
+        message(FATAL_ERROR "JUCE must be added to your project before pluginval!")
+    endif ()
 endif()
 
 # sanitizer options, from https://github.com/sudara/cmake-includes/blob/main/Sanitizers.cmake
@@ -52,11 +60,9 @@ if(PLUGINVAL_ENABLE_RTCHECK)
     CPMAddPackage("gh:Tracktion/rtcheck#main")
 endif()
 
-
-option(PLUGINVAL_FETCH_JUCE "Fetch JUCE along with pluginval" ON)
-
-if(PLUGINVAL_FETCH_JUCE)
-    add_subdirectory(modules/juce)
+# Only fetch JUCE when top-level (when used as dependency, JUCE is already available)
+if (pluginval_IS_TOP_LEVEL)
+    CPMAddPackage("gh:juce-framework/juce#8.0.3")
 endif()
 
 if (DEFINED ENV{VST2_SDK_DIR})
@@ -151,11 +157,13 @@ if (PLUGINVAL_ENABLE_RTCHECK)
     endif ()
 endif()
 
-set (cmdline_docs_out "${CMAKE_CURRENT_LIST_DIR}/docs/Command line options.md")
+if (pluginval_IS_TOP_LEVEL)
+    set (cmdline_docs_out "${CMAKE_CURRENT_LIST_DIR}/docs/Command line options.md")
 
-add_custom_command (OUTPUT "${cmdline_docs_out}"
-                    COMMAND pluginval --help > "${cmdline_docs_out}"
-                    COMMENT "Regenerating Command line options.md..."
-                    USES_TERMINAL)
+    add_custom_command (OUTPUT "${cmdline_docs_out}"
+                        COMMAND pluginval --help > "${cmdline_docs_out}"
+                        COMMENT "Regenerating Command line options.md..."
+                        USES_TERMINAL)
 
-add_custom_target (PluginvalDocs DEPENDS "${cmdline_docs_out}")
+    add_custom_target (PluginvalDocs DEPENDS "${cmdline_docs_out}")
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,22 @@ else()
     if (NOT COMMAND juce_add_module)
         message(FATAL_ERROR "JUCE must be added to your project before pluginval!")
     endif ()
+
+    option(PLUGINVAL_STRICTNESS_LEVEL "Pluginval --strictness argument" 10)
+
+    if(APPLE)
+        set(PLUGIN_TARGET "${CMAKE_PROJECT_NAME}_AU")
+    else()
+        set(PLUGIN_TARGET "${CMAKE_PROJECT_NAME}_VST3")
+    endif()
+
+    add_custom_target(${CMAKE_PROJECT_NAME}_Pluginval
+        COMMAND
+        pluginval
+        --validate ${artefact}
+        --strictness-level ${PLUGINVAL_STRICTNESS_LEVEL}
+        DEPENDS ${PLUGIN_TARGET} pluginval
+        VERBATIM)
 endif()
 
 # sanitizer options, from https://github.com/sudara/cmake-includes/blob/main/Sanitizers.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.15)
 file(STRINGS VERSION CURRENT_VERSION LIMIT_COUNT 1)
 project(pluginval VERSION ${CURRENT_VERSION})
 
-# Executes when not compiling as a "dependency" of another CMake project
+# Just compliing pluginval
 if (pluginval_IS_TOP_LEVEL)
     if (APPLE)
         # Target OS versions down to 10.11
@@ -21,22 +21,6 @@ else()
     if (NOT COMMAND juce_add_module)
         message(FATAL_ERROR "JUCE must be added to your project before pluginval!")
     endif ()
-
-    option(PLUGINVAL_STRICTNESS_LEVEL "Pluginval --strictness argument" 10)
-
-    if(APPLE)
-        set(PLUGIN_TARGET "${CMAKE_PROJECT_NAME}_AU")
-    else()
-        set(PLUGIN_TARGET "${CMAKE_PROJECT_NAME}_VST3")
-    endif()
-
-    add_custom_target(${CMAKE_PROJECT_NAME}_Pluginval
-        COMMAND
-        pluginval
-        --validate ${artefact}
-        --strictness-level ${PLUGINVAL_STRICTNESS_LEVEL}
-        DEPENDS ${PLUGIN_TARGET} pluginval
-        VERBATIM)
 endif()
 
 # sanitizer options, from https://github.com/sudara/cmake-includes/blob/main/Sanitizers.cmake
@@ -180,6 +164,27 @@ if (pluginval_IS_TOP_LEVEL)
                         COMMAND pluginval --help > "${cmdline_docs_out}"
                         COMMENT "Regenerating Command line options.md..."
                         USES_TERMINAL)
-
     add_custom_target (PluginvalDocs DEPENDS "${cmdline_docs_out}")
+else()
+    # Custom pluginval CLI target
+    set(PLUGINVAL_STRICTNESS_LEVEL 10 CACHE STRING "Pluginval --strictness argument (1-10)")
+    set_property(CACHE PLUGINVAL_STRICTNESS_LEVEL PROPERTY STRINGS 1 2 3 4 5 6 7 8 9 10)
+
+    # Set the target based on the platform
+    # Makes the assumption both are being built
+    if(APPLE)
+        set(PLUGINVAL_TARGET "${CMAKE_PROJECT_NAME}_AU")
+    else()
+        set(PLUGINVAL_TARGET "${CMAKE_PROJECT_NAME}_VST3")
+    endif()
+
+    get_target_property(artefact ${PLUGINVAL_TARGET} JUCE_PLUGIN_ARTEFACT_FILE)
+
+    # TODO: This doesn't populate the executable in clion
+    add_custom_target(${CMAKE_PROJECT_NAME}_pluginval_cli
+            COMMAND $<TARGET_FILE:pluginval>
+            --validate ${artefact}
+            --strictness-level 10
+            DEPENDS pluginval ${PLUGINVAL_TARGET}
+            COMMENT "Run pluginval CLI with strict validation")
 endif()

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ cmake --build Builds/Debug --config Debug # build
 
 ### Including within an existing JUCE project
 
-Instead of running as a separate app, you can add pluginval as a CMake target to your existing plugin project. This not only makes for a convenient debugging workflow, it gives you better stack traces.
+Instead of running as a separate app, you can add pluginval as a CMake target to your existing JUCE plugin project. This not only makes for a convenient debugging workflow, it gives you better stack traces.
 
 For example, if you add pluginval as a git submodule like so:
 ```
@@ -49,6 +49,7 @@ CPMAddPackage("gh:tracktion/pluginval#develop")
 
 Then all you need to do is call `add_subdirectory ("modules/pluginval")` in your `CMakeLists.txt`. This should be done **after** your call to `juce_add_plugin`. 
 
+Note that only JUCE 8 is currently supported/tested for this method. 
 
 ### Third-party Installation
 ###### _Chocolatey (Windows):_

--- a/README.md
+++ b/README.md
@@ -32,6 +32,24 @@ cmake -B Builds/Debug -DCMAKE_BUILD_TYPE=Debug . # configure
 cmake --build Builds/Debug --config Debug # build
 ```
 
+### Including within an existing JUCE project
+
+Instead of running as a separate app, you can add pluginval as a CMake target to your existing plugin project. This not only makes for a convenient debugging workflow, it gives you better stack traces.
+
+For example, if you add pluginval as a git submodule like so:
+```
+git submodule add -b develop git@github.com:Tracktion/pluginval.git modules/pluginval
+```
+
+or added with CPM like so:
+
+```
+CPMAddPackage("gh:tracktion/pluginval#develop")
+```
+
+Then all you need to do is call `add_subdirectory ("modules/pluginval")` in your `CMakeLists.txt`. This should be done **after** your call to `juce_add_plugin`. 
+
+
 ### Third-party Installation
 ###### _Chocolatey (Windows):_
 ```shell

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -241,7 +241,11 @@ namespace
     bool isPluginArgument (juce::String arg)
     {
         juce::AudioPluginFormatManager formatManager;
+        #if JUCE_VERSION >= 0x08000B
         juce::addDefaultFormatsToManager (formatManager);
+        #else
+        formatManager.addDefaultFormats();
+        #endif
 
         for (auto format : formatManager.getFormats())
             if (format->fileMightContainThisPluginType (arg))

--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -331,7 +331,11 @@ namespace
 MainComponent::MainComponent (Validator& v)
     : validator (v)
 {
+    #if JUCE_VERSION >= 0x08000B
     juce::addDefaultFormatsToManager (formatManager);
+    #else
+    formatManager.addDefaultFormats();
+    #endif
 
     menuBar.setModel (this);
     addAndMakeVisible (menuBar);

--- a/Source/PluginTests.cpp
+++ b/Source/PluginTests.cpp
@@ -69,7 +69,11 @@ PluginTests::PluginTests (const juce::String& fileOrIdentifier, Options opts)
 {
     jassert (fileOrIdentifier.isNotEmpty());
     jassert (juce::isPositiveAndNotGreaterThan (options.strictnessLevel, 10));
+    #if JUCE_VERSION >= 0x08000B
     juce::addDefaultFormatsToManager (formatManager);
+    #else
+    formatManager.addDefaultFormats();
+    #endif
 }
 
 PluginTests::PluginTests (const juce::PluginDescription& desc, Options opts)

--- a/tests/pluginval_as_dependency/CMakeLists.txt
+++ b/tests/pluginval_as_dependency/CMakeLists.txt
@@ -1,0 +1,31 @@
+cmake_minimum_required(VERSION 3.22)
+project(PluginvalAsDependency VERSION 1.0.0)
+
+set(JUCE_VERSION "8.0.3" CACHE STRING "JUCE version to test against")
+
+include(${CMAKE_CURRENT_LIST_DIR}/../../cmake/CPM.cmake)
+
+CPMAddPackage("gh:juce-framework/JUCE#${JUCE_VERSION}")
+
+# Minimal plugin to test pluginval as a dependency
+# Plugin name must match CMAKE_PROJECT_NAME for pluginval's CLI target to work
+# Must be defined BEFORE adding pluginval
+juce_add_plugin(${CMAKE_PROJECT_NAME}
+    PLUGIN_MANUFACTURER_CODE Test
+    PLUGIN_CODE Test
+    FORMATS VST3 AU
+    PRODUCT_NAME "TestPlugin")
+
+target_sources(${CMAKE_PROJECT_NAME} PRIVATE TestPlugin.cpp)
+target_link_libraries(${CMAKE_PROJECT_NAME} PRIVATE juce::juce_audio_processors)
+
+CPMAddPackage(
+    NAME pluginval
+    SOURCE_DIR ${CMAKE_CURRENT_LIST_DIR}/../..
+)
+
+# Verify pluginval runs and reports the expected JUCE version
+add_custom_target(verify_pluginval
+    COMMAND $<TARGET_FILE:pluginval> --help | grep "JUCE v${JUCE_VERSION}"
+    DEPENDS pluginval
+    COMMENT "Verify pluginval built with JUCE ${JUCE_VERSION}")

--- a/tests/pluginval_as_dependency/TestPlugin.cpp
+++ b/tests/pluginval_as_dependency/TestPlugin.cpp
@@ -1,0 +1,39 @@
+// Minimal JUCE plugin to test pluginval builds as a dependency
+#include <juce_audio_processors/juce_audio_processors.h>
+
+class TestProcessor : public juce::AudioProcessor
+{
+public:
+    TestProcessor()
+        : AudioProcessor (BusesProperties()
+            .withInput ("Input", juce::AudioChannelSet::stereo(), true)
+            .withOutput ("Output", juce::AudioChannelSet::stereo(), true))
+    {
+    }
+
+    const juce::String getName() const override { return "TestPlugin"; }
+    bool acceptsMidi() const override { return false; }
+    bool producesMidi() const override { return false; }
+    double getTailLengthSeconds() const override { return 0.0; }
+
+    int getNumPrograms() override { return 1; }
+    int getCurrentProgram() override { return 0; }
+    void setCurrentProgram (int) override {}
+    const juce::String getProgramName (int) override { return {}; }
+    void changeProgramName (int, const juce::String&) override {}
+
+    void prepareToPlay (double, int) override {}
+    void releaseResources() override {}
+    void processBlock (juce::AudioBuffer<float>&, juce::MidiBuffer&) override {}
+
+    bool hasEditor() const override { return false; }
+    juce::AudioProcessorEditor* createEditor() override { return nullptr; }
+
+    void getStateInformation (juce::MemoryBlock&) override {}
+    void setStateInformation (const void*, int) override {}
+};
+
+juce::AudioProcessor* JUCE_CALLTYPE createPluginFilter()
+{
+    return new TestProcessor();
+}


### PR DESCRIPTION
Closes #137 

This improves support for pluginval as a CMake sub-project in a JUCE project.

After this PR, all one needs to do is `add_subdirectory ("modules/pluginval")` to a plugin project's CMakeLists.txt.

* Moves the JUCE dependency from a submodule to CPM
* Only adds JUCE when pluginval is the top level CMake project
* Only sets deployment target and generates docs when top level
* Removes `PLUGINVAL_FETCH_JUCE` option (no longer needed, superseded by not being top level)
* Adds documentation for "pluginval as a dependency"
* Adds some conditionals around 8.0.11 deprecations to allow earlier versions of JUCE.
* Add a test for pluginval as a dependency, testing plugins running both JUCE 8.0.3 and 8.0.11

To review, the benefits are:

* Full call stack. Right now when debugging via pluginval, one only gets the exact line of code in my project vs. the full stacktrace. See #137 for an example.
* Less friction to start pluginval. Build the target from within the IDE and pluginval runs against the project. No need to open another project, pull changes, build, etc.
* Easy ability to set breakpoints in the main project
* I could add pluginval to pamplejuce so everyone starting out gets 1-click pluginval.

Note:

Technically, this feature adds an additional maintenance burden to pluginval — before this change, pluginval only had to care about working for the single JUCE version it came bundled with. Now, it would need some preprocessor `#if` statements to maintain some backwards compatibility with older JUCE versions (like I did in this PR for JUCE < 8.0.11)