### PR TITLE
Add sanitizer option to cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,9 +11,31 @@ if (APPLE)
     # set(CMAKE_OSX_ARCHITECTURES arm64 x86_64)
 endif()
 
-# Uncomment to enable tsan
-# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=thread")
+# sanitizer options, from https://github.com/sudara/cmake-includes/blob/main/Sanitizers.cmake
+# set the corresponding option ON to turn on Address/Thread Sanitizer
+option(WITH_ADDRESS_SANITIZER "Enable Address Sanitizer" OFF)
+option(WITH_THREAD_SANITIZER "Enable Thread Sanitizer" OFF)
 
+message(STATUS "Sanitizers: ASan=${WITH_ADDRESS_SANITIZER} TSan=${WITH_THREAD_SANITIZER}")
+if (WITH_ADDRESS_SANITIZER)
+    if (MSVC)
+        add_compile_options(/fsanitize=address)
+    elseif (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        # also enable UndefinedBehaviorSanitizer
+        # https://clang.llvm.org/docs/UndefinedBehaviorSanitizer.html
+        add_compile_options(-fsanitize=address,undefined -fno-omit-frame-pointer)
+        link_libraries(-fsanitize=address)
+    endif ()
+    message("Address Sanitizer enabled")
+endif ()
+
+if (WITH_THREAD_SANITIZER)
+    if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+        add_compile_options(-fsanitize=thread -g -fno-omit-frame-pointer)
+        link_libraries(-fsanitize=thread)
+        message("Thread Sanitizer enabled")
+    endif ()
+endif ()
 
 # Adds all the module sources so they appear correctly in the IDE
 set_property(GLOBAL PROPERTY USE_FOLDERS YES)


### PR DESCRIPTION
LLVM needs sanitizer flags for both the compiler and the linker. Therefore, I copy the code from https://github.com/sudara/cmake-includes/blob/main/Sanitizers.cmake and put it in the cmake. In such way, we can enable Address/Thread sanitizer from the command line instead of adjusting the cmake file. It is quite useful if we run sanitizers in CI.