### PR TITLE
Don't call getAllValueStrings for non discrete parameters

### DIFF
--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -486,7 +486,8 @@ namespace ParameterHelpers
         const int numSteps = parameter.getNumSteps();
         const bool isDiscrete = parameter.isDiscrete();
         const bool isBoolean = parameter.isBoolean();
-        const juce::StringArray allValueStrings = parameter.getAllValueStrings();
+        const juce::StringArray allValueStrings = parameter.isDiscrete() ? parameter.getAllValueStrings() : juce::StringArray();
+
 
         const bool isOrientationInverted = parameter.isOrientationInverted();
         const bool isAutomatable = parameter.isAutomatable();


### PR DESCRIPTION
Lazy solution that closes #150 

Short story: Pluginval won't run on JUCE develop without hitting assertions because of recent changes to the AU wrapper. 

This fix only touches log output.