### PR TITLE
use path to plugin bundle dir for vst3validator tests

### DIFF
--- a/Source/tests/BasicTests.cpp
+++ b/Source/tests/BasicTests.cpp
@@ -769,7 +769,7 @@ struct VST3validator    : public PluginTest
         if (ut.getOptions().strictnessLevel > 5)
             cmd.add ("-e");
 
-        cmd.add (desc.fileOrIdentifier);
+        cmd.add (ut.getFileOrID());
 
         juce::ChildProcess cp;
         const auto started = cp.start (cmd);


### PR DESCRIPTION
This commit will use the plugin bundle dir as the path to the plugin for the vst3validator. It was a problem on Linux before when the vst3validator tried to load the .so file inside the bundle dir which caused vst3validator to fail loading the plugin

This solves the issue https://github.com/Tracktion/pluginval/issues/152