### PR TITLE
Add test to ensure the locale does not change

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,6 +82,7 @@ set(SourceFiles
     Source/MainComponent.cpp
     Source/PluginTests.cpp
     Source/tests/BasicTests.cpp
+    Source/tests/LocaleTest.cpp
     Source/tests/BusTests.cpp
     Source/tests/ParameterFuzzTests.cpp
     Source/TestUtilities.cpp

--- a/Source/tests/LocaleTest.cpp
+++ b/Source/tests/LocaleTest.cpp
@@ -1,0 +1,54 @@
+/*==============================================================================
+
+  Copyright 2018 by Tracktion Corporation.
+  For more information visit www.tracktion.com
+
+   You may also use this code under the terms of the GPL v3 (see
+   www.gnu.org/licenses).
+
+   pluginval IS PROVIDED "AS IS" WITHOUT ANY WARRANTY, AND ALL WARRANTIES, WHETHER
+   EXPRESSED OR IMPLIED, INCLUDING MERCHANTABILITY AND FITNESS FOR PURPOSE, ARE
+   DISCLAIMED.
+
+ ==============================================================================*/
+
+#include "../PluginTests.h"
+#include "../TestUtilities.h"
+
+//==============================================================================
+struct LocaleTest   : public PluginTest
+{
+    LocaleTest()
+        : PluginTest ("Ensuring that the locale does not change during execution", 1)
+    {
+        startupLocale = std::setlocale(LC_ALL, nullptr);
+    }
+
+    void runTest (PluginTests& ut, juce::AudioPluginInstance& instance) override
+    {
+        ut.logMessage (juce::String ("INFO: Startup Locale: [LOC]")
+                           .replace ("LOC",juce::String (startupLocale), false));
+
+        if (instance.hasEditor())
+        {
+            ScopedPluginDeinitialiser scopedPluginDeinitialiser (instance);
+
+            {
+                ut.logMessage ("Opening editor...");
+                ScopedEditorShower editor (instance);
+            }
+        }
+
+        std::string newLocale = std::setlocale(LC_ALL, nullptr);
+        ut.expectEquals (startupLocale, newLocale, "Plugin changed locale. This can cause unexpected behavior.");
+        ut.logMessage (juce::String ("INFO: Shutdown Locale: [LOC]")
+                           .replace ("LOC",juce::String (newLocale), false));
+
+    }
+
+private:
+    std::string startupLocale;
+};
+
+static LocaleTest localeTest;
+


### PR DESCRIPTION
This is a bit quick and dirty so I am happy to spend more time on this.

The motivation behind this test is that calling`setlocale()` to set a new locale can cause issues within other plug-ins used in the same project file. In my plug-in suite, MiniMeters, I was setting the locale in my GUI code which often resulted in issues saving plug-in parameters. It was a bit tricky to pin down the issue.

This test just saves a string with the current locale in the test's constructor and compares it after opening and closing the GUI. It fails they do not match.