### PR TITLE
Add drag-and-drop plugin validation to the main window

### DIFF
--- a/Source/MainComponent.cpp
+++ b/Source/MainComponent.cpp
@@ -382,6 +382,30 @@ void MainComponent::paint (juce::Graphics& g)
     g.fillAll (getLookAndFeel().findColour (juce::ResizableWindow::backgroundColourId));
 }
 
+void MainComponent::paintOverChildren (juce::Graphics& g)
+{
+    if (! dragHighlight)
+        return;
+
+    constexpr float cornerRadius = 10.0f;
+    constexpr float borderThickness = 3.0f;
+    constexpr float inset = 6.0f;
+    const auto accent = juce::Colour (0xff4a9eff);
+
+    auto r = getLocalBounds().withTrimmedTop (menuBar.getBottom())
+                             .toFloat()
+                             .reduced (inset);
+
+    g.setColour (accent.withAlpha (0.12f));
+    g.fillRoundedRectangle (r, cornerRadius);
+
+    g.setColour (accent);
+    g.drawRoundedRectangle (r, cornerRadius, borderThickness);
+
+    g.setFont (juce::Font (juce::FontOptions (22.0f, juce::Font::bold)));
+    g.drawText ("Drop plug-in to validate", r, juce::Justification::centred);
+}
+
 void MainComponent::resized()
 {
     auto r = getLocalBounds();
@@ -417,6 +441,71 @@ void MainComponent::changeListenerCallback (juce::ChangeBroadcaster*)
 void MainComponent::validationStarted (const juce::String&)
 {
     tabbedComponent.setCurrentTabIndex (1);  // Switch to Console tab
+}
+
+//==============================================================================
+bool MainComponent::isPluginFile (const juce::String& path)
+{
+    static const juce::StringArray extensions { ".vst3", ".vst", ".component", ".dll", ".so", ".clap" };
+    const auto lower = path.toLowerCase();
+
+    for (const auto& ext : extensions)
+        if (lower.endsWith (ext))
+            return true;
+
+    return false;
+}
+
+bool MainComponent::isInterestedInFileDrag (const juce::StringArray& files)
+{
+    for (const auto& f : files)
+        if (isPluginFile (f))
+            return true;
+
+    return false;
+}
+
+void MainComponent::fileDragEnter (const juce::StringArray& files, int, int)
+{
+    const bool shouldHighlight = isInterestedInFileDrag (files);
+
+    if (dragHighlight != shouldHighlight)
+    {
+        dragHighlight = shouldHighlight;
+        repaint();
+    }
+}
+
+void MainComponent::fileDragExit (const juce::StringArray&)
+{
+    if (dragHighlight)
+    {
+        dragHighlight = false;
+        repaint();
+    }
+}
+
+void MainComponent::filesDropped (const juce::StringArray& files, int, int)
+{
+    if (dragHighlight)
+    {
+        dragHighlight = false;
+        repaint();
+    }
+
+    juce::StringArray pluginFiles;
+
+    for (const auto& f : files)
+        if (isPluginFile (f))
+            pluginFiles.add (f);
+
+    if (pluginFiles.isEmpty())
+        return;
+
+    getAppPreferences().setValue ("lastPluginLocation", pluginFiles[pluginFiles.size() - 1]);
+
+    validator.setValidateInProcess (getValidateInProcess());
+    validator.validate (pluginFiles, getTestOptions());
 }
 
 //==============================================================================

--- a/Source/MainComponent.h
+++ b/Source/MainComponent.h
@@ -381,6 +381,7 @@ private:
 */
 class MainComponent   : public juce::Component,
                         public juce::MenuBarModel,
+                        public juce::FileDragAndDropTarget,
                         private juce::ChangeListener,
                         private Validator::Listener
 {
@@ -391,6 +392,7 @@ public:
 
     //==============================================================================
     void paint (juce::Graphics&) override;
+    void paintOverChildren (juce::Graphics&) override;
     void resized() override;
 
     //==============================================================================
@@ -398,6 +400,13 @@ public:
     juce::StringArray getMenuBarNames() override;
     juce::PopupMenu getMenuForIndex (int menuIndex, const juce::String& menuName) override;
     void menuItemSelected (int menuItemID, int topLevelMenuIndex) override;
+
+    //==============================================================================
+    // FileDragAndDropTarget
+    bool isInterestedInFileDrag (const juce::StringArray& files) override;
+    void fileDragEnter (const juce::StringArray& files, int x, int y) override;
+    void fileDragExit (const juce::StringArray& files) override;
+    void filesDropped (const juce::StringArray& files, int x, int y) override;
 
 private:
     //==============================================================================
@@ -417,6 +426,9 @@ private:
                strictnessInfoButton { "Strictness" };
     StatusBar statusBar { validator };
     std::unique_ptr<StrictnessInfoDialog> strictnessDialog;
+    bool dragHighlight = false;
+
+    static bool isPluginFile (const juce::String& path);
 
     void savePluginList();
     juce::PopupMenu createFileMenu();


### PR DESCRIPTION
## Summary
- Drop a `.vst3` / `.vst` / `.component` / `.dll` / `.so` / `.clap` anywhere on the pluginval window to validate it.
- Shows a translucent rounded-rectangle overlay with a "Drop plug-in to validate" label while dragging an accepted file.
- Routes through `Validator::validate(StringArray, options)` — the same flow used by **Test File…**, so it picks up the current strictness level, timeout, sample rates, etc. Console tab is auto-activated when validation starts (existing behaviour).
- Mixed drops accept the plugin files and ignore the rest; drops with no plugin files are a no-op.

## Test plan
- [x] Drag a `.vst3` onto the window — highlight appears, drop starts validation.
- [x] Drag a non-plugin file (e.g. `.txt`) — no highlight, drop is ignored.
- [x] Drag multiple plugins at once — all are queued via a single `validate` call.
- [x] Drag onto the Console tab as well as the Plugin List tab — both trigger validation (plugin list table doesn't intercept drops).