### PR TITLE
Bump JUCE to 8.0.13

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -175,7 +175,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-15, windows-latest]
-        juce: ["8.0.3", "8.0.11"]
+        juce: ["8.0.13"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 # Only fetch JUCE when top-level (when used as dependency, JUCE is already available)
 if (pluginval_IS_TOP_LEVEL)
-    CPMAddPackage("gh:juce-framework/juce#8.0.3")
+    CPMAddPackage("gh:juce-framework/juce#8.0.13")
 endif()
 
 

--- a/Source/PluginvalLookAndFeel.h
+++ b/Source/PluginvalLookAndFeel.h
@@ -215,24 +215,24 @@ public:
         auto textColour = button.isFrontTab() ? findColour (juce::Label::textColourId)
                                                : findColour (juce::Label::textColourId).withAlpha (0.6f);
         g.setColour (textColour);
-        g.setFont (juce::Font (14.0f));
+        g.setFont (juce::Font (juce::FontOptions (14.0f)));
         g.drawText (button.getButtonText(), area.reduced (12.0f, 0.0f), juce::Justification::centred);
     }
 
     int getTabButtonBestWidth (juce::TabBarButton& button, int tabDepth) override
     {
-        auto width = juce::Font (14.0f).getStringWidth (button.getButtonText()) + 40;  // Extra padding
+        auto width = juce::GlyphArrangement::getStringWidthInt (juce::Font (juce::FontOptions (14.0f)), button.getButtonText()) + 40;  // Extra padding
         return juce::jmax (width, 80);
     }
 
     juce::Font getTextButtonFont (juce::TextButton&, int buttonHeight) override
     {
-        return juce::Font (juce::jmin (14.0f, (float) buttonHeight * 0.6f));
+        return juce::Font (juce::FontOptions (juce::jmin (14.0f, (float) buttonHeight * 0.6f)));
     }
 
     juce::Font getLabelFont (juce::Label&) override
     {
-        return juce::Font (14.0f);
+        return juce::Font (juce::FontOptions (14.0f));
     }
 
     void drawTableHeaderColumn (juce::Graphics& g, juce::TableHeaderComponent& header,

--- a/Source/TestUtilities.h
+++ b/Source/TestUtilities.h
@@ -145,7 +145,7 @@ static std::unique_ptr<juce::AudioProcessorEditor> createAndShowEditorOnMessageT
             return {};
 
         jassert (instance.getActiveEditor() == nullptr);
-        editor.reset (instance.createEditor());
+        editor.reset (instance.createEditorAndMakeActive());
 
         if (editor)
         {
@@ -177,6 +177,7 @@ static void deleteEditorOnMessageThread (std::unique_ptr<juce::AudioProcessorEdi
 {
     if (juce::MessageManager::getInstance()->isThisTheMessageThread())
     {
+        editor->processor.editorBeingDeleted (editor.get());
         editor.reset();
         return;
     }
@@ -184,6 +185,8 @@ static void deleteEditorOnMessageThread (std::unique_ptr<juce::AudioProcessorEdi
     juce::WaitableEvent waiter;
     juce::MessageManager::callAsync ([&]
                                {
+                                   if (editor != nullptr)
+                                       editor->processor.editorBeingDeleted (editor.get());
                                    editor.reset();
                                    waiter.signal();
                                });


### PR DESCRIPTION
A couple of fixes for pluginval to be happy with JUCE 8.0.13. 

Main issue: `createEditor()` is private now, which means we have to use `createEditorAndMakeActive` (and tear it down afterwards). 

This also removes 8.0.3 from tests in favor of 8.0.13 only, based on prior conversation with @drowaudio that we don't need to support multiple JUCE versions when pluginval is used as a dependency.