### PR TITLE
Restructure CLI into validate/run-tests/strictness-help subcommands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -104,7 +104,7 @@ jobs:
         run: |
           pwd
           ls -ahl
-          ${{ matrix.test-binary }} --run-tests
+          ${{ matrix.test-binary }} run-tests
 
       - name: Cache JUCE example plugin binaries
         id: cache-plugins
@@ -127,9 +127,9 @@ jobs:
       - name: Validate JUCE Plugin examples (VST3)
         shell: bash
         run: |
-          # Paths must be single quoted for bash not to escape the Windows backslash character \ used in absolute paths 
-          ${{ env.APP_DIR }}/${{ matrix.test-binary }} --strictness-level 10 --validate '${{ env.PLUGIN_CACHE_PATH }}/DSPModulePluginDemo_artefacts/Release/VST3/DSPModulePluginDemo.vst3'
-          ${{ env.APP_DIR }}/${{ matrix.test-binary }} --strictness-level 10 --validate '${{ env.PLUGIN_CACHE_PATH }}/MultiOutSynthPlugin_artefacts/Release/VST3/MultiOutSynthPlugin.vst3'
+          # Paths must be single quoted for bash not to escape the Windows backslash character \ used in absolute paths
+          ${{ env.APP_DIR }}/${{ matrix.test-binary }} validate --strictness-level 10 '${{ env.PLUGIN_CACHE_PATH }}/DSPModulePluginDemo_artefacts/Release/VST3/DSPModulePluginDemo.vst3'
+          ${{ env.APP_DIR }}/${{ matrix.test-binary }} validate --strictness-level 10 '${{ env.PLUGIN_CACHE_PATH }}/MultiOutSynthPlugin_artefacts/Release/VST3/MultiOutSynthPlugin.vst3'
 
       - name: Validate JUCE Plugin examples (AU)
         shell: bash
@@ -141,6 +141,8 @@ jobs:
           mkdir -p ~/Library/Audio/Plug-Ins/Components/
           cp -R ${{ env.PLUGIN_CACHE_PATH }}/DSPModulePluginDemo_artefacts/Release/AU/DSPModulePluginDemo.component ~/Library/Audio/Plug-Ins/Components/
           killall -9 AudioComponentRegistrar # kick the AU registrar
+          # Intentionally uses the deprecated "--validate" flat flag to keep the
+          # backwards-compatible alias covered (this step is continue-on-error).
           ${{ env.APP_DIR }}/${{ matrix.test-binary }} --strictness-level 10 --validate  ~/Library/Audio/Plug-Ins/Components/DSPModulePluginDemo.component
 
       - name: Codesign (macOS)

--- a/CHANGELIST.md
+++ b/CHANGELIST.md
@@ -1,6 +1,8 @@
 # pluginval Change List
 
 ### 2.0.0
+- Restructured the command line into subcommands: `pluginval validate [options] <plugin>` (the default), `pluginval run-tests` and `pluginval strictness-help [level]`. The plugin path is now a positional argument of `validate`
+- **Deprecated:** the flat flags `--validate <plugin>`, `--run-tests` and `--strictness-help [level]` still work as aliases (with a one-line notice) but will be removed in a future version. `pluginval <plugin>` remains a silent shorthand for `validate`
 - Replaced the hand-rolled command-line parser with CLI11 and a single JSON-based settings pipeline
 - Added `--config <file.json>` to load settings from JSON (repeatable; later files win per key)
 - Settings precedence is now (lowest to highest): defaults, environment variables, `--config`, command-line options

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -193,6 +193,38 @@ VST2_SDK_DIR=/path/to/vst2sdk cmake -B Builds/Debug .
 
 ### CLI Settings Pipeline
 
+#### Subcommand dispatch layer
+
+The command line is structured into subcommands, peeled off by a thin verb
+dispatcher in front of the settings pipeline (it does **not** use CLI11-native
+subcommands, so the env/config/CLI layering below is untouched):
+
+- `pluginval validate [options] <plugin>` — the default; `<plugin>` is a
+  positional argument. `pluginval <plugin>` and `pluginval [options] <plugin>`
+  (no verb) also resolve to validate.
+- `pluginval run-tests` — runs the internal unit tests.
+- `pluginval strictness-help [level]` — lists tests at a strictness level.
+
+`settings_parser::dispatch()` (in `SettingsParser.cpp`) takes the `tokenise()`d
+command line and returns a `DispatchResult { command, validateTokens,
+deprecatedAlias, strictnessLevel }`. For `validate` it strips the verb and hands
+`validateTokens` to `parseTokens` unchanged. `CommandLine.cpp`'s
+`performCommandLine()` switches on `command` and emits a one-line stderr notice
+when `deprecatedAlias` is set.
+
+The old flat flags (`--validate <plugin>`, `--run-tests`, `--strictness-help`)
+are kept as **deprecated aliases** that route to the same commands with
+`deprecatedAlias = true` (the bare-path shorthand and the internal child handoff
+stay silent). `preprocess()` is now `tokenise()` + `insertImplicitValidate()`.
+The child process is launched with the explicit verb:
+`validate --config-base64 <b64> <path>`.
+
+Note: `--config` is parsed manually (it is stripped from the tokens fed to the
+CLI11 pass) so its greedy CLI11 vector parsing can't swallow the positional
+plugin path; it stays registered only so it appears in `--help`.
+
+#### Settings layering
+
 Command-line parsing centres on one plain settings struct (`PluginvalSettings`)
 that CLI11 binds to directly. A single instance is filled by successive layers,
 **lowest to highest precedence: defaults → environment → `--config` → CLI**
@@ -360,11 +392,17 @@ ut.logVerboseMessage("Detail message");  // Only with --verbose flag
 
 Basic usage:
 ```bash
-./pluginval --strictness-level 5 /path/to/plugin.vst3
+./pluginval validate --strictness-level 5 /path/to/plugin.vst3
 ```
 
-Key options:
-- `--validate [path]` - Validate plugin at path
+Commands:
+- `validate [options] <plugin>` - Validate the plugin at the given path/AU id (the default; `./pluginval <plugin>` also works)
+- `run-tests` - Run the internal unit tests
+- `strictness-help [level]` - List the tests that run at a strictness level
+
+The flat flags `--validate <plugin>`, `--run-tests` and `--strictness-help [level]` are deprecated aliases.
+
+Key options (for `validate`):
 - `--config [file.json]` - Load a full settings set from JSON (overridden by env vars and CLI options)
 - `--strictness-level [1-10]` - Test thoroughness (default: 5)
 - `--skip-gui-tests` - Skip GUI tests (for headless CI)
@@ -434,7 +472,7 @@ Debug unit tests run automatically in debug builds:
 
 Run internal tests via CLI:
 ```bash
-./pluginval --run-tests
+./pluginval run-tests
 ```
 
 ## Release Process

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -250,8 +250,9 @@ else()
     # TODO: This doesn't populate the executable in clion
     add_custom_target(${CMAKE_PROJECT_NAME}_pluginval_cli
             COMMAND $<TARGET_FILE:pluginval>
-            --validate ${artefact}
+            validate
             --strictness-level 10
+            ${artefact}
             DEPENDS pluginval ${PLUGINVAL_TARGET}
             COMMENT "Run pluginval CLI with strict validation")
 endif()

--- a/Source/CommandLine.cpp
+++ b/Source/CommandLine.cpp
@@ -203,38 +203,47 @@ juce::StringArray createCommandLine (juce::String fileOrID, PluginTests::Options
 }
 
 //==============================================================================
+static void warnDeprecated (const juce::String& oldForm, const juce::String& newForm)
+{
+    std::cerr << "!!! WARNING: " << oldForm << " is deprecated; use '" << newForm
+              << "' instead. It will be removed in a future version." << std::endl;
+}
+
 void performCommandLine (CommandLineValidator& validator, const juce::String& commandLine)
 {
     hideDockIcon();
 
     auto& app = *juce::JUCEApplication::getInstance();
-    const auto tokens = settings_parser::preprocess (commandLine);
+    const auto routed = settings_parser::dispatch (settings_parser::tokenise (commandLine));
 
-    if (tokens.contains ("--run-tests"))
+    if (routed.command == settings_parser::Command::runTests)
     {
+        if (routed.deprecatedAlias)
+            warnDeprecated ("--run-tests", "pluginval run-tests");
+
         runUnitTests();
         app.quit();
         return;
     }
 
-    if (tokens.contains ("--strictness-help"))
+    if (routed.command == settings_parser::Command::strictnessHelp)
     {
-        int level = 5;
+        if (routed.deprecatedAlias)
+            warnDeprecated ("--strictness-help", "pluginval strictness-help");
 
-        if (const auto idx = tokens.indexOf ("--strictness-help"); idx >= 0 && idx + 1 < tokens.size())
-            if (const auto next = tokens[idx + 1]; ! next.startsWith ("-"))
-                level = next.getIntValue();
-
-        printStrictnessHelp (level);
+        printStrictnessHelp (routed.strictnessLevel);
         app.quit();
         return;
     }
 
-    // Otherwise this is a validation run (explicit or implicit --validate).
-    // CLI11 handles --help/--version and parse errors.
+    // Otherwise this is a validation run (positional plugin, or explicit/implicit
+    // --validate). CLI11 handles --help/--version and parse errors.
+    if (routed.deprecatedAlias)
+        warnDeprecated ("--validate", "pluginval validate <plugin>");
+
     try
     {
-        const auto result = settings_parser::parseTokens (tokens);
+        const auto result = settings_parser::parseTokens (routed.validateTokens);
 
         if (result.handled)
         {

--- a/Source/CommandLineTests.cpp
+++ b/Source/CommandLineTests.cpp
@@ -331,6 +331,112 @@ struct CommandLineTests : public juce::UnitTest
                 expectEquals (r.exitCode, 1);
             }
         }
+
+        beginTest ("Subcommand: validate with a positional plugin path");
+        {
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
+
+            // Plugin path as a positional after the verb.
+            expectEquals (juce::String (parse ("validate MyPlugin.vst3").validatePath),
+                          currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
+
+            // Options before the positional plugin path.
+            const auto s = parse ("validate --strictness-level 8 MyPlugin.vst3");
+            expectEquals (s.strictnessLevel, 8);
+            expectEquals (juce::String (s.validatePath), currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
+
+            // A bare AU component id positional is left untouched.
+            expectEquals (juce::String (parse ("validate MyPluginID").validatePath), juce::String ("MyPluginID"));
+        }
+
+        beginTest ("Subcommand: validate with --config before the positional plugin");
+        {
+            juce::TemporaryFile configFile (".json");
+            configFile.getFile().replaceWithText (R"({ "strictnessLevel": 2 })");
+
+            const auto currentDir = juce::File::getCurrentWorkingDirectory();
+            const auto cmd = "validate --config " + configFile.getFile().getFullPathName().quoted() + " MyPlugin.vst3";
+
+            const auto s = parse (cmd);
+            expectEquals (s.strictnessLevel, 2);   // --config didn't swallow the plugin path
+            expectEquals (juce::String (s.validatePath), currentDir.getChildFile ("MyPlugin.vst3").getFullPathName());
+        }
+
+        beginTest ("Subcommand dispatch routing (new verbs do not warn)");
+        {
+            using settings_parser::Command;
+
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("run-tests"));
+                expect (d.command == Command::runTests);
+                expect (! d.deprecatedAlias);
+            }
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("strictness-help 7"));
+                expect (d.command == Command::strictnessHelp);
+                expectEquals (d.strictnessLevel, 7);
+                expect (! d.deprecatedAlias);
+            }
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("strictness-help"));
+                expect (d.command == Command::strictnessHelp);
+                expectEquals (d.strictnessLevel, 5);   // default level
+            }
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("validate MyPlugin.vst3"));
+                expect (d.command == Command::validate);
+                expect (! d.deprecatedAlias);
+            }
+        }
+
+        beginTest ("Deprecated flat flags still route, flagged as deprecated");
+        {
+            using settings_parser::Command;
+
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("--run-tests"));
+                expect (d.command == Command::runTests);
+                expect (d.deprecatedAlias);
+            }
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("--strictness-help 9"));
+                expect (d.command == Command::strictnessHelp);
+                expectEquals (d.strictnessLevel, 9);
+                expect (d.deprecatedAlias);
+            }
+            {
+                const auto d = settings_parser::dispatch (settings_parser::tokenise ("--validate x"));
+                expect (d.command == Command::validate);
+                expect (d.deprecatedAlias);
+            }
+        }
+
+        beginTest ("Bare-path shorthand and child handoff do not warn");
+        {
+            juce::TemporaryFile temp ("path_to_file.vst3");
+            expect (temp.getFile().create());
+
+            // Bare plugin path -> validate, no deprecation warning.
+            const auto bare = settings_parser::dispatch (settings_parser::tokenise (temp.getFile().getFullPathName()));
+            expect (bare.command == settings_parser::Command::validate);
+            expect (! bare.deprecatedAlias);
+
+            // The internal child handoff uses the explicit verb -> no warning.
+            PluginTests::Options opts;
+            juce::StringArray childArgs (createCommandLine ("/some/MyPlugin.vst3", opts));
+            childArgs.remove (0); // drop the executable path
+            const auto child = settings_parser::dispatch (childArgs);
+            expect (child.command == settings_parser::Command::validate);
+            expect (! child.deprecatedAlias);
+        }
+
+        beginTest ("Should perform command line recognises subcommands");
+        {
+            expect (shouldPerformCommandLine ("run-tests"));
+            expect (shouldPerformCommandLine ("strictness-help"));
+            expect (shouldPerformCommandLine ("validate MyPlugin.vst3"));
+            expect (shouldPerformCommandLine ("validate MyPluginID"));
+        }
     }
 };
 

--- a/Source/SettingsParser.cpp
+++ b/Source/SettingsParser.cpp
@@ -126,9 +126,13 @@ namespace settings_parser
         juce::String getFooterText()
         {
             return juce::SystemStats::getJUCEVersion() + "\n\n" + juce::String (
-R"(Other commands:
-  --run-tests                 Run the internal unit tests.
-  --strictness-help [level]   List all tests that run at the given strictness level.
+R"(Commands:
+  validate [options] <plugin>   Validate the plugin at the given path or AU id (the default).
+  run-tests                     Run the internal unit tests.
+  strictness-help [level]       List all tests that run at the given strictness level.
+
+The flat flags --validate <plugin>, --run-tests and --strictness-help [level] are
+deprecated aliases for the commands above and will be removed in a future version.
 
 Exit code:
   0 if all tests complete successfully
@@ -172,6 +176,9 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
                 "Path to a JSON settings file. Repeatable; later files win per key.")->take_all();
 
             app.add_option ("--validate", s.validatePath, "Validates the plugin at the given path (or AU id).");
+            // The new canonical form: "pluginval validate <plugin>". Bound to the
+            // same member as --validate; whichever is supplied sets the path.
+            app.add_option ("plugin", s.validatePath, "Plugin path or AU id to validate.");
             app.add_option ("--strictness-level", s.strictnessLevel, "Strictness level 1-10 (default 5).");
             app.add_option ("--timeout-ms", s.timeoutMs, "Test timeout in ms (default 30000, -1 to never timeout).");
             app.add_option ("--repeat", s.numRepeats, "Number of times to repeat the tests.");
@@ -254,7 +261,7 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
     }
 
     //==============================================================================
-    juce::StringArray preprocess (const juce::String& commandLineIn)
+    juce::StringArray tokenise (const juce::String& commandLineIn)
     {
         if (commandLineIn.contains ("strictnessLevel"))
         {
@@ -273,6 +280,11 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
         for (auto& s : args)
             s = s.unquoted();
 
+        return args;
+    }
+
+    void insertImplicitValidate (juce::StringArray& args)
+    {
         // If only a plugin path is supplied as the last arg, add an implicit
         // --validate option for it so the rest of the CLI works.
         if (args.size() > 0)
@@ -286,18 +298,98 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
             if (! hasCommand && isPluginArgument (args[args.size() - 1]))
                 args.insert (args.size() - 1, "--validate");
         }
+    }
 
+    juce::StringArray preprocess (const juce::String& commandLine)
+    {
+        auto args = tokenise (commandLine);
+        insertImplicitValidate (args);
         return args;
     }
 
     bool isCommandLine (const juce::StringArray& tokens)
     {
+        if (! tokens.isEmpty())
+        {
+            const auto& verb = tokens.getReference (0);
+
+            if (verb == "validate" || verb == "run-tests" || verb == "strictness-help")
+                return true;
+        }
+
         return tokens.contains ("--help") || tokens.contains ("-h")
             || tokens.contains ("--version")
             || hasOption (tokens, "--validate")
             || tokens.contains ("--run-tests")
             || tokens.contains ("--strictness-help")
             || hasOption (tokens, "--config-base64");
+    }
+
+    //==============================================================================
+    DispatchResult dispatch (const juce::StringArray& tokensIn)
+    {
+        DispatchResult result;
+
+        // The optional [level] argument that follows the strictness-help command/flag.
+        const auto levelAfter = [] (const juce::StringArray& tokens, int idx)
+        {
+            if (idx >= 0 && idx + 1 < tokens.size())
+                if (const auto& next = tokens.getReference (idx + 1); ! next.startsWith ("-"))
+                    return juce::jlimit (1, 10, next.getIntValue());
+
+            return 5;
+        };
+
+        // 1. Explicit subcommand verbs (the new, non-deprecated syntax).
+        if (! tokensIn.isEmpty())
+        {
+            const auto& verb = tokensIn.getReference (0);
+
+            if (verb == "validate")
+            {
+                result.command = Command::validate;
+                result.validateTokens = tokensIn;
+                result.validateTokens.remove (0);   // the plugin path is captured by the positional CLI option
+                return result;
+            }
+
+            if (verb == "run-tests")
+            {
+                result.command = Command::runTests;
+                return result;
+            }
+
+            if (verb == "strictness-help")
+            {
+                result.command = Command::strictnessHelp;
+                result.strictnessLevel = levelAfter (tokensIn, 0);
+                return result;
+            }
+        }
+
+        // 2. Deprecated flat command flags.
+        if (tokensIn.contains ("--run-tests"))
+        {
+            result.command = Command::runTests;
+            result.deprecatedAlias = true;
+            return result;
+        }
+
+        if (tokensIn.contains ("--strictness-help"))
+        {
+            result.command = Command::strictnessHelp;
+            result.deprecatedAlias = true;
+            result.strictnessLevel = levelAfter (tokensIn, tokensIn.indexOf ("--strictness-help"));
+            return result;
+        }
+
+        // 3. Default: validate. An explicit --validate flag (but not the bare-path
+        //    shorthand, nor the internal --config-base64 handoff) is a deprecated alias.
+        result.command = Command::validate;
+        result.deprecatedAlias = hasOption (tokensIn, "--validate") && ! hasOption (tokensIn, "--config-base64");
+        result.validateTokens = tokensIn;
+        insertImplicitValidate (result.validateTokens);
+        return result;
     }
 
     juce::String resolvePluginPath (const juce::String& raw)
@@ -375,8 +467,18 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
 
             std::vector<std::string> argv { "pluginval" };
 
-            for (const auto& t : tokens)
+            // --config is handled manually above; drop it (and its value) here so
+            // its greedy CLI11 vector parsing can't swallow the positional plugin
+            // path. It stays registered purely so it appears in --help.
+            for (int i = 0; i < tokens.size(); ++i)
+            {
+                const auto& t = tokens.getReference (i);
+
+                if (t == "--config")        { ++i; continue; }  // skip the flag and its value
+                if (t.startsWith ("--config=")) continue;       // skip the inline form
+
                 argv.push_back (t.toStdString());
+            }
 
             if (const auto code = runParse (cliApp, argv); code)
             {
@@ -392,7 +494,7 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
 
     PluginvalSettings parse (const juce::String& commandLine, const EnvProvider& env)
     {
-        return parseTokens (preprocess (commandLine), env).settings;
+        return parseTokens (dispatch (tokenise (commandLine)).validateTokens, env).settings;
     }
 
     //==============================================================================
@@ -403,7 +505,7 @@ Precedence (lowest to highest): defaults, environment variables, --config, comma
         const auto b64 = juce::Base64::toBase64 (juce::String (jsonString));
 
         juce::StringArray args (juce::File::getSpecialLocation (juce::File::currentExecutableFile).getFullPathName());
-        args.addArray ({ "--config-base64", b64, "--validate", fileOrID });
+        args.addArray ({ "validate", "--config-base64", b64, fileOrID });
         return args;
     }
 }

--- a/Source/SettingsParser.h
+++ b/Source/SettingsParser.h
@@ -38,20 +38,55 @@ namespace settings_parser
     juce::String systemEnv (const juce::String& name);
 
     //==============================================================================
-    /** Tokenises + preprocesses a raw command line: rewrites the deprecated
-        "strictnessLevel", strips the macOS "-NSDocumentRevisionsDebugMode YES"
-        flag, and inserts an implicit "--validate" when the last argument is a
-        bare plugin path. Returns argv tokens (without the program name).
+    /** Tokenises a raw command line: rewrites the deprecated "strictnessLevel",
+        strips the macOS "-NSDocumentRevisionsDebugMode YES" flag, splits and
+        unquotes. Returns argv tokens (without the program name) exactly as the
+        user typed them - it does NOT insert an implicit "--validate".
     */
+    juce::StringArray tokenise (const juce::String& commandLine);
+
+    /** Inserts an implicit "--validate" when the last token is a bare plugin path
+        (and no command is already present). This is the documented shorthand for
+        "pluginval <plugin>".
+    */
+    void insertImplicitValidate (juce::StringArray& tokens);
+
+    /** Convenience: tokenise + insertImplicitValidate. */
     juce::StringArray preprocess (const juce::String& commandLine);
 
-    /** True if the tokens contain a recognised command that triggers CLI mode. */
+    /** True if the tokens contain a recognised command (subcommand verb or legacy
+        flag) that triggers CLI mode. */
     bool isCommandLine (const juce::StringArray& tokens);
 
     /** Resolves a relative/home plugin path against the working directory,
         leaving absolute paths and bare component IDs untouched.
     */
     juce::String resolvePluginPath (const juce::String& raw);
+
+    //==============================================================================
+    /** The subcommand selected on the command line. */
+    enum class Command
+    {
+        validate,        /**< Validate a plugin (the default when no verb is given). */
+        runTests,        /**< Run the internal unit tests. */
+        strictnessHelp   /**< List the tests that run at a given strictness level. */
+    };
+
+    /** The outcome of routing tokens to a subcommand. */
+    struct DispatchResult
+    {
+        Command command = Command::validate;
+        juce::StringArray validateTokens;   /**< Verb-stripped option tokens to feed parseTokens (validate only). */
+        bool deprecatedAlias = false;       /**< A legacy flat flag (--validate/--run-tests/--strictness-help) was used. */
+        int strictnessLevel = 5;            /**< The level for the strictnessHelp command. */
+    };
+
+    /** Routes tokenised input to a subcommand, peeling the leading verb. The
+        validate token-layering in parseTokens is left untouched; the plugin path
+        is captured by a positional CLI option there. Legacy flat flags map onto
+        the matching command with deprecatedAlias set.
+    */
+    DispatchResult dispatch (const juce::StringArray& tokens);
 
     //==============================================================================
     /** The outcome of parsing the option tokens. */
@@ -70,7 +105,7 @@ namespace settings_parser
 
     //==============================================================================
     /** Serialises options for the child validation process as a base64 JSON
-        handoff: { exe, --config-base64 <b64>, --validate <fileOrID> }.
+        handoff: { exe, validate, --config-base64 <b64>, <fileOrID> }.
     */
     juce::StringArray createChildProcessCommandLine (const juce::String& fileOrID, const PluginTests::Options&);
 

--- a/docs/Adding pluginval to CI.md
+++ b/docs/Adding pluginval to CI.md
@@ -19,21 +19,21 @@ In these examples the following is assumed:
 ```sh
 $ curl -L "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_macOS.zip" -o pluginval.zip
 $ unzip pluginval
-$ pluginval.app/Contents/MacOS/pluginval --validate-in-process --output-dir "./bin" "<path_to_plugin>" || exit 1
+$ pluginval.app/Contents/MacOS/pluginval validate --output-dir "./bin" "<path_to_plugin>" || exit 1
 ```
 
 ##### Linux
 ```sh
 $ curl -L "https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_Linux.zip" -o pluginval.zip
 $ unzip pluginval
-$ ./pluginval --validate-in-process --output-dir "./bin" "<path_to_plugin>" || exit 1
+$ ./pluginval validate --output-dir "./bin" "<path_to_plugin>" || exit 1
 ```
 
 ##### Windows
 ```sh
 > powershell -Command "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest https://github.com/Tracktion/pluginval/releases/latest/download/pluginval_Windows.zip -OutFile pluginval.zip"
 > powershell -Command "Expand-Archive pluginval.zip -DestinationPath ."
-> pluginval.exe --validate-in-process --output-dir "./bin" "<path_to_plugin>"
+> pluginval.exe validate --output-dir "./bin" "<path_to_plugin>"
 > if %ERRORLEVEL% neq 0 exit /b 1
 ```
 

--- a/docs/Command line options.md
+++ b/docs/Command line options.md
@@ -2,10 +2,22 @@ Validate plugins to test compatibility with hosts and verify plugin API
 conformance
 
 
-pluginval [OPTIONS]
+pluginval <command> [OPTIONS] [plugin]
 
 
-OPTIONS:
+COMMANDS:
+  validate [options] <plugin>   Validate the plugin at the given path or AU id.
+                                This is the default, so "pluginval <plugin>" and
+                                "pluginval [options] <plugin>" also work.
+  run-tests                     Run the internal unit tests.
+  strictness-help [level]       List all tests that run at the given strictness level.
+
+The flat flags --validate <plugin>, --run-tests and --strictness-help [level]
+are deprecated aliases for the commands above and will be removed in a future
+version.
+
+
+OPTIONS (for the validate command):
   -h,     --help              Print this help message and exit
           --version           Display program version information and exit
           --config TEXT ...   Path to a JSON settings file. Repeatable; later files win per
@@ -32,19 +44,12 @@ OPTIONS:
           --rtcheck ENUM:value in {disabled->0,enabled->1,relaxed->2} OR {0,1,2} 
                               Real-time safety checks: disabled, enabled or relaxed.
 
-JUCE v8.0.13
-
-Other commands:
---run-tests Run the internal unit tests.
---strictness-help [level] List all tests that run at the given strictness level.
-
 Exit code:
 0 if all tests complete successfully
 1 if there are any errors
 
 You can also specify any option as an environment variable by removing the
-prefix
-dashes, converting internal dashes to underscores and capitalising, e.g.
+prefix dashes, converting internal dashes to underscores and capitalising, e.g.
 "--skip-gui-tests" -> "SKIP_GUI_TESTS=1"
 "--timeout-ms 30000" -> "TIMEOUT_MS=30000"
 Precedence (lowest to highest): defaults, environment variables, --config,

--- a/tests/AddPluginvalTests.cmake
+++ b/tests/AddPluginvalTests.cmake
@@ -81,13 +81,14 @@ function (add_pluginval_tests pluginTarget)
 
 	add_test (NAME "${test_name}"
 			  COMMAND "${PLUGINVAL_PROGRAM}"
+						validate
 						--strictness-level "${PLUGINVAL_STRICTNESS}"
 						--sample-rates "${sample_rates}"
 						--block-sizes "${block_sizes}"
 						--repeat "${PLUGINVAL_REPEATS}"
 						--randomise
-						--validate "${plugin_artefact}"
 						${log_dir_arg}
+						"${plugin_artefact}"
 	)
 
 	set_tests_properties (

--- a/tests/windows_tests.bat
+++ b/tests/windows_tests.bat
@@ -64,11 +64,11 @@ exit /B %ERRORLEVEL%
     "%MSBUILD_EXE%" %PLUGIN_NAME%.sln /p:VisualStudioVersion=15.0 /m /t:Build /p:Configuration=Release /p:Platform=x64 /p:PreferredToolArchitecture=x64  /p:TreatWarningsAsErrors=true
 
     :: Test in process
-    call "%PLUGINVAL_EXE%" --validate-in-process --strictness-level 5 --validate %PLUGIN_VST3%
+    call "%PLUGINVAL_EXE%" validate --strictness-level 5 %PLUGIN_VST3%
     if %ERRORLEVEL% NEQ 0 exit 1
 
     :: Test out of process
-    :: call "%PLUGINVAL_EXE%" --strictness-level 5 --validate %PLUGIN_VST3%
+    :: call "%PLUGINVAL_EXE%" validate --strictness-level 5 %PLUGIN_VST3%
     :: if %ERRORLEVEL% NEQ 0 exit 1
 
 exit /B 0


### PR DESCRIPTION
## What

Restructures pluginval's command line into proper subcommands, with the old flat flags kept as **deprecated aliases for one release**:

| New (canonical) | Old (deprecated alias) |
|---|---|
| `pluginval validate [options] <plugin>` (the default) | `pluginval --validate <plugin>` |
| `pluginval run-tests` | `pluginval --run-tests` |
| `pluginval strictness-help [level]` | `pluginval --strictness-help [level]` |
| `pluginval <plugin>` (bare-path shorthand) | unchanged, stays silent |

This was the work deliberately deferred from the CLI11 refactor (#175); the settings pipeline and `PluginvalSettings` were designed to be reused unchanged.

## How

A thin **verb dispatcher** sits in front of the existing settings pipeline — *not* CLI11-native subcommands — so the env → `--config` → CLI precedence layering in `parseTokens` is completely untouched.

- `SettingsParser`: split `preprocess()` into `tokenise()` + `insertImplicitValidate()`; added `Command`, `DispatchResult` and `dispatch()`, which peels the leading verb and records whether a deprecated alias was used.
- The plugin path is now a **positional** CLI option (bound to the same member as `--validate`), so `validate <plugin>` works for file paths *and* AU component ids.
- `--config` is stripped from the tokens fed to the CLI11 pass (it's parsed manually anyway) so its greedy vector parsing can't swallow the positional plugin path.
- The parent→child handoff now uses the explicit verb: `validate --config-base64 <b64> <path>`.
- `CommandLine.cpp` switches on the dispatched command and prints a one-line stderr deprecation notice when an old flat flag is used (the bare-path shorthand and the internal child handoff stay silent).

## Deprecation behaviour

`--validate` / `--run-tests` / `--strictness-help` still work but emit e.g.:

```
!!! WARNING: --validate is deprecated; use 'pluginval validate <plugin>' instead. It will be removed in a future version.
```

To be removed in the release after next (noted in `CHANGELIST.md`).

## Tests / verification

- Added 6 `CommandLineTests` groups: positional validate, `--config`-before-plugin (the swallow guard), verb routing (no warning), deprecated aliases (warn), bare-path/child-handoff silence, and `shouldPerformCommandLine` verb recognition.
- Full unit suite passes locally (`run-tests`, exit 0) and CI is green on all three platforms — including the Windows **Run Pluginval Tests** and **Validate VST3 examples** steps, plus all three "Pluginval as Dependency" jobs that exercise the updated `AddPluginvalTests.cmake`.

## Also updated

- `.github/workflows/build.yaml` — new syntax, keeping one `--validate` alias invocation (the continue-on-error AU step) so the deprecation path stays covered.
- `tests/AddPluginvalTests.cmake` (public CTest module) and the `CMakeLists.txt` dev target → new `validate` syntax so downstream users don't get warnings.
- `tests/windows_tests.bat` — replaced the stale `--validate-in-process` flag (no longer registered) with `validate`.
- Docs (`Command line options.md`, `Adding pluginval to CI.md` — also fixed its broken `--validate-in-process` examples), `CHANGELIST.md`, and `CLAUDE.md`.

## Reviewer notes

- The `--config` token-stripping in `parseTokens` step 3 is the one non-obvious bit — it exists purely to stop CLI11's greedy vector parse from consuming the positional plugin path. `--config` is still parsed manually and still appears in `--help`.
- `--validate` warns when used directly, but the internal child-process handoff uses the explicit `validate` verb so it never triggers the warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)